### PR TITLE
Fix for #110 (deleting an ABCD attendance template should delete the generated attendance templates)

### DIFF
--- a/tapir/shifts/models.py
+++ b/tapir/shifts/models.py
@@ -256,10 +256,11 @@ class ShiftAttendanceTemplate(models.Model):
 def on_shift_attendance_template_delete(
     sender, instance: ShiftAttendanceTemplate, using, **kwargs
 ):
-    slots = instance.slot_template.generated_slots()
-    for slot in slots:
+    for slot in instance.slot_template.generated_slots.all():
         attendances = ShiftAttendance.objects.filter(slot=slot)
-        for attendance in slot.attendances.filter(start_date__gte=timezone.now(), user=instance.user):
+        for attendance in slot.attendances.filter(
+            slot__shift__start_time__gte=timezone.now(), user=instance.user
+        ):
             if attendance.user == instance.user:
                 attendance.delete()
 

--- a/tapir/shifts/models.py
+++ b/tapir/shifts/models.py
@@ -259,7 +259,7 @@ def on_shift_attendance_template_delete(
     slots = ShiftSlot.objects.filter(slot_template=instance.slot_template)
     for slot in slots:
         attendances = ShiftAttendance.objects.filter(slot=slot)
-        for attendance in attendances:
+        for attendance in slot.attendances.filter(start_date__gte=timezone.now(), user=instance.user):
             if attendance.user == instance.user:
                 attendance.delete()
 

--- a/tapir/shifts/models.py
+++ b/tapir/shifts/models.py
@@ -256,7 +256,7 @@ class ShiftAttendanceTemplate(models.Model):
 def on_shift_attendance_template_delete(
     sender, instance: ShiftAttendanceTemplate, using, **kwargs
 ):
-    slots = ShiftSlot.objects.filter(slot_template=instance.slot_template)
+    slots = instance.slot_template.generated_slots()
     for slot in slots:
         attendances = ShiftAttendance.objects.filter(slot=slot)
         for attendance in slot.attendances.filter(start_date__gte=timezone.now(), user=instance.user):

--- a/tapir/shifts/tests/tests_unit.py
+++ b/tapir/shifts/tests/tests_unit.py
@@ -1,4 +1,6 @@
 from datetime import time, date, datetime
+from django.test import Client
+from django.urls import reverse
 
 from tapir.accounts.models import TapirUser
 from tapir.shifts.models import (
@@ -12,11 +14,8 @@ from tapir.utils.tests_utils import LdapEnabledTestCase
 
 class ShiftsTestCase(LdapEnabledTestCase):
     def test_shift_template_update_shift_attendances(self):
-        user1 = TapirUser.objects.create(
+        user = TapirUser.objects.create(
             username="ariana.perrin", email="ariana.perrin@supercoop.de"
-        )
-        user2 = TapirUser.objects.create(
-            username="nicolas.vicente", email="nicolas.vicente@supercoop.de"
         )
 
         shift_template = ShiftTemplate.objects.create(
@@ -29,10 +28,49 @@ class ShiftsTestCase(LdapEnabledTestCase):
         self.assertQuerysetEqual(shift.get_attendances().all(), [])
 
         # Create an attendance for the shift template
-        ShiftAttendanceTemplate.objects.create(slot_template=slot_template, user=user1)
+        shift_attendance_template = ShiftAttendanceTemplate.objects.create(
+            slot_template=slot_template, user=user
+        )
         shift_template.update_future_shift_attendances(
             now=datetime(2021, 3, 24, 0, 0, 0)
         )
 
         # Verify that the already-created shift instance was updated
-        self.assertEqual(shift.get_attendances().all()[0].user, user1)
+        self.assertEqual(shift.get_attendances().all()[0].user, user)
+
+        shift_attendance_template.delete()
+        self.assertEqual(shift.get_attendances().count(), 0)
+
+    def test_on_attendance_template_delete(self):
+        user1 = TapirUser.objects.create(
+            username="ariana.perrin", email="ariana.perrin@supercoop.de"
+        )
+        user2 = TapirUser.objects.create(
+            username="john.doe", email="john.doe@supercoop.de"
+        )
+
+        shift_template = ShiftTemplate.objects.create(
+            start_time=time(15, 00), end_time=time(18, 00)
+        )
+        slot_template = ShiftSlotTemplate.objects.create(shift_template=shift_template)
+        shift1 = shift_template.create_shift(start_date=date(2021, 3, 24))
+        shift2 = shift_template.create_shift(start_date=date(2021, 3, 25))
+
+        ShiftAttendance.objects.create(slot=shift1.slots.all()[0], user=user1)
+
+        shift_attendance_template = ShiftAttendanceTemplate.objects.create(
+            slot_template=slot_template, user=user2
+        )
+        shift_template.update_future_shift_attendances(
+            now=datetime(2021, 3, 24, 0, 0, 0)
+        )
+
+        self.assertEqual(shift1.get_attendances().all()[0].user, user1)
+        self.assertEqual(shift1.get_attendances().count(), 1)
+        self.assertEqual(shift2.get_attendances().all()[0].user, user2)
+        self.assertEqual(shift2.get_attendances().count(), 1)
+
+        shift_attendance_template.delete()
+        self.assertEqual(shift1.get_attendances().all()[0].user, user1)
+        self.assertEqual(shift1.get_attendances().count(), 1)
+        self.assertEqual(shift2.get_attendances().count(), 0)


### PR DESCRIPTION
I added a pre_delete trigger on ShiftAttendanceTemplate, just wanted to check that there isn't a better django-way of doing.