### PR TITLE
[shifts] Allow users with shifts.manage to edit ShiftTemplates

### DIFF
--- a/tapir/admin.py
+++ b/tapir/admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+
+
+class TapirAdminSite(admin.AdminSite):
+    def has_permission(self, request):
+        """This function only controls whether the admin app can be accessed
+        at all. Individual model access is controlled in the ModelAdmin instances.
+        """
+        return super().has_permission(request) or request.user.has_perm("shifts.manage")

--- a/tapir/apps.py
+++ b/tapir/apps.py
@@ -1,0 +1,5 @@
+from django.contrib.admin.apps import AdminConfig
+
+
+class TapirAdminConfig(AdminConfig):
+    default_site = "tapir.admin.TapirAdminSite"

--- a/tapir/settings.py
+++ b/tapir/settings.py
@@ -41,7 +41,8 @@ ENABLE_SILK_PROFILING = False
 INSTALLED_APPS = [
     # Must come before contrib.auth to let the custom templates be discovered for auth views
     "tapir.accounts",
-    "django.contrib.admin",
+    # Install custom admin config to allow non-is_staff-users
+    "tapir.apps.TapirAdminConfig",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/tapir/shifts/admin.py
+++ b/tapir/shifts/admin.py
@@ -14,18 +14,35 @@ from tapir.shifts.models import (
 admin.site.register(ShiftUserData)
 
 
-class ShiftTemplateInline(admin.TabularInline):
+class ShiftAdminPermissionMixin:
+    def has_module_permission(self, request):
+        return request.user.has_perm("shifts.manage")
+
+    def has_view_permission(self, request, obj=None):
+        return request.user.has_perm("shifts.manage")
+
+    def has_add_permission(self, request, obj=None):
+        return request.user.has_perm("shifts.manage")
+
+    def has_change_permission(self, request, obj=None):
+        return request.user.has_perm("shifts.manage")
+
+    def has_delete_permission(self, request, obj=None):
+        return request.user.has_perm("shifts.manage")
+
+
+class ShiftTemplateInline(ShiftAdminPermissionMixin, admin.TabularInline):
     model = ShiftTemplate
     show_change_link = True
     extra = 3
 
 
 @admin.register(ShiftTemplateGroup)
-class ShiftTemplateGroupAdmin(admin.ModelAdmin):
+class ShiftTemplateGroupAdmin(ShiftAdminPermissionMixin, admin.ModelAdmin):
     inlines = [ShiftTemplateInline]
 
 
-class ShiftSlotTemplateInline(admin.TabularInline):
+class ShiftSlotTemplateInline(ShiftAdminPermissionMixin, admin.TabularInline):
     model = ShiftSlotTemplate
     extra = 1
 
@@ -36,7 +53,7 @@ class ShiftInline(admin.TabularInline):
 
 
 @admin.register(ShiftTemplate)
-class ShiftTemplateAdmin(admin.ModelAdmin):
+class ShiftTemplateAdmin(ShiftAdminPermissionMixin, admin.ModelAdmin):
     inlines = [ShiftSlotTemplateInline, ShiftInline]
 
 
@@ -46,7 +63,7 @@ class ShiftAttendanceTemplateInline(admin.TabularInline):
 
 
 @admin.register(ShiftSlotTemplate)
-class ShiftSlotTemplateAdmin(admin.ModelAdmin):
+class ShiftSlotTemplateAdmin(ShiftAdminPermissionMixin, admin.ModelAdmin):
     inlines = [ShiftAttendanceTemplateInline]
 
 


### PR DESCRIPTION
Hopefully this will allow changes to the shift calendar to be done by
the users themselves. The interface is a bit rough, but only the shift
admin will likely ever see it.

Do we need a new permission for this? And do you think this is even useful?