### PR TITLE
fix link to material icons in pdf css

### DIFF
--- a/tapir/coop/static/coop/css/membership_agreement_pdf.css
+++ b/tapir/coop/static/coop/css/membership_agreement_pdf.css
@@ -12,15 +12,14 @@ html {
 }
 
 @font-face {
-  font-family: 'Material Icons';
-  font-style: normal;
-  font-weight: 400;
-  src: url(/static/material-icons/MaterialIcons-Regular.eot); /* For IE6-8 */
-  src: local('Material Icons'),
-    local('MaterialIcons-Regular'),
-    url(/static/material-icons/MaterialIcons-Regular.woff2) format('woff2'),
-    url(/static/material-icons/MaterialIcons-Regular.woff) format('woff'),
-    url(/static/material-icons/MaterialIcons-Regular.ttf) format('truetype');
+    font-family: 'Material Icons';
+    font-style: normal;
+    font-weight: 400;
+    src: url(/static/core/material-icons/MaterialIcons-Regular.6.4.2.eot); /* For IE6-8 */
+    src:
+            url(/static/core/material-icons/MaterialIcons-Regular.6.4.2.woff2) format('woff2'),
+            url(/static/core/material-icons/MaterialIcons-Regular.6.4.2.woff) format('woff'),
+            url(/static/core/material-icons/MaterialIcons-Regular.6.4.2.ttf) format('truetype');
 }
 
 .material-icons {


### PR DESCRIPTION
When "core" package was introduced, these links weren't updated.