### PR TITLE
Shift accounts updates

### DIFF
--- a/tapir/coop/templates/coop/welcome_desk_share_owner.html
+++ b/tapir/coop/templates/coop/welcome_desk_share_owner.html
@@ -22,33 +22,41 @@
         <div class="card-body">
             {% if can_shop %}
                 <div class="alert alert-success" role="alert" id="welcome_desk_can_shop">
-                    {% blocktranslate with name=share_owner.get_info.first_name %}{{ name }}  can shop :){% endblocktranslate %}
+                    {% blocktranslate with name=share_owner.get_info.first_name %}{{ name }}  can shop
+                        :){% endblocktranslate %}
                 </div>
             {% else %}
                 {% if missing_account %}
                     <div class="alert alert-danger" role="alert" id="welcome_desk_no_account">
-                        {% blocktranslate with name=share_owner.get_info.first_name %}{{ name }} does not have a Tapir account. Contact a member of the management team.{% endblocktranslate %}
+                        {% blocktranslate with name=share_owner.get_info.first_name %}{{ name }} does not have a Tapir
+                            account. Contact a member of the management team.{% endblocktranslate %}
                     </div>
                 {% endif %}
                 {% if shift_balance_not_ok %}
                     <div class="alert alert-danger" role="alert" id="welcome_desk_shift_balance_not_ok">
-                        {% blocktranslate with name=share_owner.get_info.first_name %}{{ name }} has a negative shift balance. Contact a member of the management team.{% endblocktranslate %}
+                        {% blocktranslate with name=share_owner.get_info.first_name balance=share_owner.user.shift_user_data.get_account_balance %}
+                            {{ name }} has a negative shift balance ({{ balance }}). Contact a member of the management
+                            team.{% endblocktranslate %}
                     </div>
                 {% endif %}
                 {% if share_owner.is_investing %}
                     <div class="alert alert-danger" role="alert" id="welcome_desk_is_investing">
-                        {% blocktranslate with name=share_owner.get_info.first_name %}{{ name }} is an investing member. If they want to shop, they have to become an active member. Contact a member of the management team.{% endblocktranslate %}
+                        {% blocktranslate with name=share_owner.get_info.first_name %}{{ name }} is an investing member.
+                            If they want to shop, they have to become an active member. Contact a member of the
+                            management team.{% endblocktranslate %}
                     </div>
                 {% endif %}
             {% endif %}
             {% if must_register_to_a_shift %}
                 <div class="alert alert-warning" role="alert" id="welcome_desk_no_abcd_shift">
-                    {% blocktranslate with name=share_owner.get_info.first_name %}{{ name }} is not registered to an ABCD shift yet. Make sure they plan to do it!{% endblocktranslate %}
+                    {% blocktranslate with name=share_owner.get_info.first_name %}{{ name }} is not registered to an
+                        ABCD shift yet. Make sure they plan to do it!{% endblocktranslate %}
                 </div>
             {% endif %}
             {% if not share_owner.attended_welcome_session %}
                 <div class="alert alert-warning" role="alert" id="welcome_desk_no_welcome_session">
-                    {% blocktranslate with name=share_owner.get_info.first_name %}{{ name }} has not attended a welcome session yet. Make sure they plan to do it!{% endblocktranslate %}
+                    {% blocktranslate with name=share_owner.get_info.first_name %}{{ name }} has not attended a welcome
+                        session yet. Make sure they plan to do it!{% endblocktranslate %}
                 </div>
             {% endif %}
         </div>

--- a/tapir/core/templatetags/core.py
+++ b/tapir/core/templatetags/core.py
@@ -98,6 +98,11 @@ def get_sidebar_link_groups(request):
             material_icon="calculate",
             url=reverse_lazy("shifts:statistics"),
         )
+        shifts_group.add_link(
+            display_name=_("Members on alert"),
+            material_icon="priority_high",
+            url=reverse_lazy("shifts:members_on_alert"),
+        )
 
     if FinancingCampaign.objects.exists():
         campaign_group = SidebarLinkGroup(name=_("Financing campaign"))

--- a/tapir/settings.py
+++ b/tapir/settings.py
@@ -125,6 +125,10 @@ CELERY_BEAT_SCHEDULE = {
             hour="*/2", minute=5
         ),  # Every two hours five after the hour
     },
+    "apply_shift_cycle_start": {
+        "task": "tapir.shifts.tasks.apply_shift_cycle_start",
+        "schedule": celery.schedules.crontab(hour="*/2", minute=20),
+    },
 }
 
 # Password validation

--- a/tapir/shifts/management/commands/apply_shift_cycle_start.py
+++ b/tapir/shifts/management/commands/apply_shift_cycle_start.py
@@ -24,8 +24,11 @@ class Command(BaseCommand):
         if new_cycle_start_date is None:
             return
 
-        if datetime.date.today() >= new_cycle_start_date:
+        while datetime.date.today() >= new_cycle_start_date:
             ShiftCycleEntry.apply_cycle_start(new_cycle_start_date)
+            new_cycle_start_date += datetime.timedelta(
+                days=ShiftCycleEntry.SHIFT_CYCLE_DURATION
+            )
 
     @staticmethod
     def get_first_cycle_start_date():

--- a/tapir/shifts/management/commands/apply_shift_cycle_start.py
+++ b/tapir/shifts/management/commands/apply_shift_cycle_start.py
@@ -1,0 +1,42 @@
+import datetime
+
+from django.core.management.base import BaseCommand
+from django.db.models import Max
+
+from tapir.shifts.models import ShiftCycleEntry, ShiftTemplateGroup, Shift
+from tapir.utils.shortcuts import get_monday
+
+
+class Command(BaseCommand):
+    help = "If a new cycle has started, remove one shift point from all active members."
+
+    def handle(self, *args, **options):
+        if ShiftCycleEntry.objects.exists():
+            last_cycle_date: datetime.date = ShiftCycleEntry.objects.aggregate(
+                Max("cycle_start_date")
+            )["cycle_start_date__max"]
+            new_cycle_start_date = last_cycle_date + datetime.timedelta(
+                days=ShiftCycleEntry.SHIFT_CYCLE_DURATION
+            )
+        else:
+            new_cycle_start_date = self.get_first_cycle_start_date()
+
+        if new_cycle_start_date is None:
+            return
+
+        if datetime.date.today() >= new_cycle_start_date:
+            ShiftCycleEntry.apply_cycle_start(new_cycle_start_date)
+
+    @staticmethod
+    def get_first_cycle_start_date():
+        first_shift = (
+            Shift.objects.filter(
+                shift_template__group=ShiftTemplateGroup.objects.first()
+            )
+            .order_by("start_time")
+            .first()
+        )
+        if not first_shift:
+            return None
+
+        return get_monday(first_shift.start_time.date())

--- a/tapir/shifts/models.py
+++ b/tapir/shifts/models.py
@@ -958,11 +958,16 @@ class ShiftUserData(models.Model):
     def get_credit_requirement_for_cycle(self, cycle_start_date: datetime.date):
         if not hasattr(self.user, "share_owner") or self.user.share_owner is None:
             return 0
-        if (
-            not self.user.share_owner.is_active()
-            or self.is_currently_exempted_from_shifts(cycle_start_date)
-        ):
+
+        if not self.user.share_owner.is_active():
             return 0
+
+        if self.user.date_joined.date() > cycle_start_date:
+            return 0
+
+        if self.is_currently_exempted_from_shifts(cycle_start_date):
+            return 0
+
         return 1
 
 

--- a/tapir/shifts/models.py
+++ b/tapir/shifts/models.py
@@ -1046,6 +1046,8 @@ class ShiftCycleEntry(models.Model):
             )
         ]
 
+    SHIFT_CYCLE_DURATION = 28
+
     shift_user_data = models.ForeignKey(
         ShiftUserData, related_name="shift_cycle_logs", on_delete=models.CASCADE
     )

--- a/tapir/shifts/tasks.py
+++ b/tapir/shifts/tasks.py
@@ -5,3 +5,8 @@ from django.core.management import call_command
 @shared_task
 def send_shift_reminders():
     call_command("send_shift_reminders")
+
+
+@shared_task
+def apply_shift_cycle_start():
+    call_command("apply_shift_cycle_start")

--- a/tapir/shifts/templates/shifts/members_on_alert_list.html
+++ b/tapir/shifts/templates/shifts/members_on_alert_list.html
@@ -1,0 +1,41 @@
+{% extends "core/base.html" %}
+
+{% load render_table from django_tables2 %}
+{% load django_bootstrap5 %}
+{% load i18n %}
+{% load static %}
+{% load querystring from django_tables2 %}
+{% load export_url from django_tables2 %}
+
+{% block content %}
+
+    <div class="card m-2">
+        <div class="card-header d-flex justify-content-between">
+            <h5>{% translate "Members on alert" %}</h5>
+            <div class="btn-group">
+                <button type="button" class="btn tapir-btn btn-outline-secondary btn-sm dropdown-toggle"
+                        data-bs-toggle="dropdown">
+                    {% translate "Export" %}
+                </button>
+                <div class="dropdown-menu dropdown-menu-right">
+                    {% for format in view.export_formats %}
+                        <a class="dropdown-item" href="{% export_url format %}">
+                            download <code>.{{ format }}</code>
+                        </a>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+        <ul class="list-group list-group-flush">
+            <li class="list-group-item">
+                {% blocktranslate %}
+                    The members in this list are on alert relative to their shift account : the current balance is -2
+                    or less.
+                {% endblocktranslate %}
+            </li>
+            <li class="list-group-item">
+                {% render_table table %}
+            </li>
+        </ul>
+    </div>
+{% endblock %}

--- a/tapir/shifts/templates/shifts/statistics.html
+++ b/tapir/shifts/templates/shifts/statistics.html
@@ -67,11 +67,9 @@
             </div>
         </div>
         <div class="card m-2">
-            <div class="card-header">
-                <h5 class="d-flex justify-content-between align-items-center">
-                    <span>{% translate "Shift cycle list" %}</span>
-                </h5>
-            </div>
+            <h5 class="card-header">
+                <span>{% translate "Shift cycle list" %}</span>
+            </h5>
             <div class="card-body">
                 <ul>
                     {% for cycle in cycles %}

--- a/tapir/shifts/templates/shifts/statistics.html
+++ b/tapir/shifts/templates/shifts/statistics.html
@@ -16,7 +16,8 @@
                         <ul>
                             <li>Out of those {{ members.active_users_count }}, {{ members.exempted_users_count }} are
                                 currently exempted from
-                                doing shifts. This leaves {{ members.users_doing_shifts_count }} who are expected to do shifts.
+                                doing shifts. This leaves {{ members.users_doing_shifts_count }} who are expected to do
+                                shifts.
                             </li>
                             <li>There are currently {{ members.abcd_slots_count }} ABCD shift slots, which
                                 is {{ members.extra_abcd_slots_count }} more than users expected to do shifts.
@@ -62,6 +63,21 @@
                             {% endfor %}
                         </table>
                     </li>
+                </ul>
+            </div>
+        </div>
+        <div class="card m-2">
+            <div class="card-header">
+                <h5 class="d-flex justify-content-between align-items-center">
+                    <span>{% translate "Shift cycle list" %}</span>
+                </h5>
+            </div>
+            <div class="card-body">
+                <ul>
+                    {% for cycle in cycles %}
+                        <li>{{ cycle.date|date:"d.m.Y" }} : {{ cycle.nb_members_doing_shifts }} members where expected
+                            to do a shift out of {{ cycle.nb_members_total }}</li>
+                    {% endfor %}
                 </ul>
             </div>
         </div>

--- a/tapir/shifts/templatetags/shifts.py
+++ b/tapir/shifts/templatetags/shifts.py
@@ -11,6 +11,7 @@ from tapir.shifts.models import (
     ShiftAttendance,
     ShiftTemplateGroup,
 )
+from tapir.utils.shortcuts import get_monday
 
 register = template.Library()
 
@@ -175,9 +176,7 @@ def shift_filters(context):
 @register.simple_tag
 def get_week_group(target_time: date) -> ShiftTemplateGroup | None:
     for delta in list(range(52)) + list(range(-52, 0)):
-        monday = (
-            target_time - timedelta(days=target_time.weekday()) + timedelta(weeks=delta)
-        )
+        monday = get_monday(target_time) + timedelta(weeks=delta)
         monday = datetime.combine(monday, time(), timezone.now().tzinfo)
         sunday = monday + timedelta(days=7)
         shifts = Shift.objects.filter(

--- a/tapir/shifts/urls.py
+++ b/tapir/shifts/urls.py
@@ -118,4 +118,9 @@ urlpatterns = [
         views.StatisticsView.as_view(),
         name="statistics",
     ),
+    path(
+        "members_on_alert",
+        views.MembersOnAlertView.as_view(),
+        name="members_on_alert",
+    ),
 ]

--- a/tapir/shifts/views/calendars.py
+++ b/tapir/shifts/views/calendars.py
@@ -13,6 +13,7 @@ from tapir.shifts.models import (
 )
 from tapir.shifts.templatetags.shifts import get_week_group
 from tapir.shifts.views.views import get_shift_slot_names, SelectedUserViewMixin
+from tapir.utils.shortcuts import get_monday
 
 
 class ShiftCalendarBaseView(TemplateView):
@@ -141,7 +142,7 @@ class ShiftTemplateGroupCalendar(LoginRequiredMixin, TemplateView):
         date_to_group = {}
         today = timezone.now().date()
         for week in range(52):
-            monday = today - timedelta(days=today.weekday()) + timedelta(weeks=week)
+            monday = get_monday(today) + timedelta(weeks=week)
             date_to_group[monday] = get_week_group(monday).name
         context["date_to_group"] = date_to_group
         return context

--- a/tapir/shifts/views/statistics.py
+++ b/tapir/shifts/views/statistics.py
@@ -19,6 +19,7 @@ from tapir.shifts.models import (
     ShiftUserData,
     ShiftCycleEntry,
 )
+from tapir.utils.shortcuts import get_monday
 
 
 class StatisticsView(LoginRequiredMixin, TemplateView):
@@ -98,7 +99,7 @@ class StatisticsView(LoginRequiredMixin, TemplateView):
         weeks = {"Last": -1, "Current": 0, "Next": 1}
         for week, delta in weeks.items():
             week_context = {}
-            monday = today - timedelta(days=today.weekday()) + timedelta(weeks=delta)
+            monday = get_monday(today) + timedelta(weeks=delta)
             week_start = datetime.datetime.combine(
                 monday, datetime.time(hour=0, minute=0), timezone.now().tzinfo
             )

--- a/tapir/utils/management/commands/populate_functions.py
+++ b/tapir/utils/management/commands/populate_functions.py
@@ -23,6 +23,7 @@ from tapir.shifts.models import (
 )
 from tapir.utils.json_user import JsonUser
 from tapir.utils.models import copy_user_info
+from tapir.utils.shortcuts import get_monday
 
 SHIFT_NAME_CASHIER_MORNING = "Cashier morning"
 SHIFT_NAME_CASHIER_AFTERNOON = "Cashier afternoon"
@@ -325,9 +326,7 @@ def populate_shift_templates():
 def generate_shifts(print_progress=False):
     if print_progress:
         print("Generating shifts")
-    start_day = datetime.date.today() - datetime.timedelta(days=20)
-    while start_day.weekday() != 0:
-        start_day = start_day + datetime.timedelta(days=1)
+    start_day = get_monday(datetime.date.today() - datetime.timedelta(days=20))
 
     groups = ShiftTemplateGroup.objects.all()
     for week in range(8):

--- a/tapir/utils/shortcuts.py
+++ b/tapir/utils/shortcuts.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.shortcuts import redirect
 from django.utils.encoding import iri_to_uri
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -14,3 +16,7 @@ def safe_redirect(redirect_url, default, request):
 
     url = iri_to_uri(redirect_url)
     return redirect(url)
+
+
+def get_monday(date: datetime.date):
+    return date - datetime.timedelta(days=date.weekday())


### PR DESCRIPTION
Hey,

At SuperCoop Berlin we're not actually using the shift account balance yet : we do add to or remove from it when shift attendances get updated, but we we not removing the one credit at the beginning of each cycle. This PR intends to do that.

@fabiangebert I tagged you just to warn you about the new celery task. I'm not sure if you have a shift cycle or if you use ShiftTemplateGroup at all?

Overall there is :
- A change in ShiftUserData.get_account_balance that checks if the member existed at the given date
- A new view that lists the members that have a negative balance (<= -2), with an export for sending them all an email.
- A new celery task that checks regularly if a new cycle start should be applied