### PR TITLE
Move share price configuration to settings.py and fix mailchimp export

### DIFF
--- a/tapir/coop/config.py
+++ b/tapir/coop/config.py
@@ -1,0 +1,4 @@
+from decimal import Decimal
+
+COOP_SHARE_PRICE = Decimal(100)
+COOP_ENTRY_AMOUNT = Decimal(10)

--- a/tapir/coop/models.py
+++ b/tapir/coop/models.py
@@ -1,5 +1,3 @@
-from decimal import Decimal
-
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
@@ -10,15 +8,12 @@ from phonenumber_field.modelfields import PhoneNumberField
 from tapir import utils
 from tapir.accounts.models import TapirUser
 from tapir.log.models import UpdateModelLogEntry, ModelLogEntry
-from tapir.shifts.models import ShiftAttendanceTemplate
+from tapir.settings import COOP_SHARE_PRICE, COOP_ENTRY_AMOUNT
 from tapir.utils.models import (
     DurationModelMixin,
     CountryField,
 )
 from tapir.utils.user_utils import UserUtils
-
-COOP_SHARE_PRICE = Decimal(100)
-COOP_ENTRY_AMOUNT = Decimal(10)
 
 
 class ShareOwner(models.Model):

--- a/tapir/coop/models.py
+++ b/tapir/coop/models.py
@@ -7,8 +7,8 @@ from phonenumber_field.modelfields import PhoneNumberField
 
 from tapir import utils
 from tapir.accounts.models import TapirUser
+from tapir.coop.config import COOP_SHARE_PRICE, COOP_ENTRY_AMOUNT
 from tapir.log.models import UpdateModelLogEntry, ModelLogEntry
-from tapir.settings import COOP_SHARE_PRICE, COOP_ENTRY_AMOUNT
 from tapir.utils.models import (
     DurationModelMixin,
     CountryField,

--- a/tapir/coop/tests/factories.py
+++ b/tapir/coop/tests/factories.py
@@ -1,7 +1,8 @@
 import factory
 
 from tapir.accounts.tests.factories.user_data_factory import UserDataFactory
-from tapir.coop.models import ShareOwnership, ShareOwner, DraftUser, COOP_SHARE_PRICE
+from tapir.coop.models import ShareOwnership, ShareOwner, DraftUser
+from tapir.settings import COOP_SHARE_PRICE
 
 
 class ShareOwnershipFactory(factory.django.DjangoModelFactory):

--- a/tapir/coop/tests/factories.py
+++ b/tapir/coop/tests/factories.py
@@ -1,8 +1,8 @@
 import factory
 
 from tapir.accounts.tests.factories.user_data_factory import UserDataFactory
+from tapir.coop.config import COOP_SHARE_PRICE
 from tapir.coop.models import ShareOwnership, ShareOwner, DraftUser
-from tapir.settings import COOP_SHARE_PRICE
 
 
 class ShareOwnershipFactory(factory.django.DjangoModelFactory):

--- a/tapir/coop/tests/test_draft_user_to_share_owner.py
+++ b/tapir/coop/tests/test_draft_user_to_share_owner.py
@@ -1,9 +1,9 @@
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 
+from tapir.coop.config import COOP_SHARE_PRICE
 from tapir.coop.models import DraftUser, ShareOwner, ShareOwnership
 from tapir.coop.tests.factories import DraftUserFactory, ShareOwnerFactory
-from tapir.settings import COOP_SHARE_PRICE
 from tapir.utils.tests_utils import TapirFactoryTestBase
 
 

--- a/tapir/coop/tests/test_draft_user_to_share_owner.py
+++ b/tapir/coop/tests/test_draft_user_to_share_owner.py
@@ -1,8 +1,9 @@
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 
-from tapir.coop.models import DraftUser, ShareOwner, ShareOwnership, COOP_SHARE_PRICE
+from tapir.coop.models import DraftUser, ShareOwner, ShareOwnership
 from tapir.coop.tests.factories import DraftUserFactory, ShareOwnerFactory
+from tapir.settings import COOP_SHARE_PRICE
 from tapir.utils.tests_utils import TapirFactoryTestBase
 
 

--- a/tapir/coop/tests/test_share_owner_list_filters.py
+++ b/tapir/coop/tests/test_share_owner_list_filters.py
@@ -5,8 +5,9 @@ from django.urls import reverse
 from django.utils import timezone
 
 from tapir.accounts.tests.factories.factories import TapirUserFactory
-from tapir.coop.models import ShareOwnership, COOP_SHARE_PRICE, MemberStatus
+from tapir.coop.models import ShareOwnership, MemberStatus
 from tapir.coop.tests.factories import ShareOwnerFactory
+from tapir.settings import COOP_SHARE_PRICE
 from tapir.shifts.models import (
     ShiftTemplateGroup,
     ShiftSlotTemplate,

--- a/tapir/coop/tests/test_share_owner_list_filters.py
+++ b/tapir/coop/tests/test_share_owner_list_filters.py
@@ -5,9 +5,9 @@ from django.urls import reverse
 from django.utils import timezone
 
 from tapir.accounts.tests.factories.factories import TapirUserFactory
+from tapir.coop.config import COOP_SHARE_PRICE
 from tapir.coop.models import ShareOwnership, MemberStatus
 from tapir.coop.tests.factories import ShareOwnerFactory
-from tapir.settings import COOP_SHARE_PRICE
 from tapir.shifts.models import (
     ShiftTemplateGroup,
     ShiftSlotTemplate,

--- a/tapir/coop/tests/tests_paid_share.py
+++ b/tapir/coop/tests/tests_paid_share.py
@@ -1,7 +1,8 @@
-from tapir.coop.models import DraftUser, ShareOwnership, COOP_SHARE_PRICE
+from tapir.coop.models import ShareOwnership
 from tapir.coop.tests.factories import DraftUserFactory
 from tapir.coop.views import create_share_owner_and_shares_from_draft_user
-from tapir.utils.tests_utils import LdapEnabledTestCase, TapirFactoryTestBase
+from tapir.settings import COOP_SHARE_PRICE
+from tapir.utils.tests_utils import TapirFactoryTestBase
 
 
 class PaidShareTests(TapirFactoryTestBase):

--- a/tapir/coop/tests/tests_paid_share.py
+++ b/tapir/coop/tests/tests_paid_share.py
@@ -1,7 +1,7 @@
+from tapir.coop.config import COOP_SHARE_PRICE
 from tapir.coop.models import ShareOwnership
 from tapir.coop.tests.factories import DraftUserFactory
 from tapir.coop.views import create_share_owner_and_shares_from_draft_user
-from tapir.settings import COOP_SHARE_PRICE
 from tapir.utils.tests_utils import TapirFactoryTestBase
 
 

--- a/tapir/coop/views/draftuser.py
+++ b/tapir/coop/views/draftuser.py
@@ -19,8 +19,8 @@ from tapir.coop.models import (
     DraftUser,
     ShareOwner,
     ShareOwnership,
-    COOP_SHARE_PRICE,
 )
+from tapir.settings import COOP_SHARE_PRICE
 from tapir.utils.models import copy_user_info
 
 

--- a/tapir/coop/views/draftuser.py
+++ b/tapir/coop/views/draftuser.py
@@ -11,6 +11,7 @@ from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_POST, require_GET
 
 from tapir.coop import pdfs
+from tapir.coop.config import COOP_SHARE_PRICE
 from tapir.coop.forms import (
     DraftUserForm,
     DraftUserRegisterForm,
@@ -20,7 +21,6 @@ from tapir.coop.models import (
     ShareOwner,
     ShareOwnership,
 )
-from tapir.settings import COOP_SHARE_PRICE
 from tapir.utils.models import copy_user_info
 
 

--- a/tapir/coop/views/shareowner.py
+++ b/tapir/coop/views/shareowner.py
@@ -39,12 +39,11 @@ from tapir.coop.models import (
     MEMBER_STATUS_CHOICES,
     MemberStatus,
     get_member_status_translation,
-    COOP_SHARE_PRICE,
 )
 from tapir.log.models import EmailLogEntry, LogEntry
 from tapir.log.util import freeze_for_log
 from tapir.log.views import UpdateViewLogMixin
-from tapir.settings import FROM_EMAIL_MEMBER_OFFICE
+from tapir.settings import FROM_EMAIL_MEMBER_OFFICE, COOP_SHARE_PRICE
 from tapir.shifts.models import (
     ShiftUserData,
     SHIFT_USER_CAPABILITY_CHOICES,

--- a/tapir/coop/views/shareowner.py
+++ b/tapir/coop/views/shareowner.py
@@ -545,7 +545,15 @@ class ShareOwnerExportMailchimpView(
                 lang_tag = '"Deutsch"'
             if owner.get_info().preferred_language == "en":
                 lang_tag = '"English"'
-            writer.writerow([owner.get_info().email, "", "", "", lang_tag])
+            writer.writerow(
+                [
+                    owner.get_info().email,
+                    owner.get_info().first_name,
+                    owner.get_info().last_name,
+                    owner.get_info().street,
+                    lang_tag,
+                ]
+            )
 
         return response
 

--- a/tapir/coop/views/shareowner.py
+++ b/tapir/coop/views/shareowner.py
@@ -27,6 +27,7 @@ from django_tables2.export import ExportMixin
 from tapir import settings
 from tapir.accounts.models import TapirUser
 from tapir.coop import pdfs
+from tapir.coop.config import COOP_SHARE_PRICE
 from tapir.coop.forms import (
     ShareOwnershipForm,
     ShareOwnerForm,
@@ -43,7 +44,7 @@ from tapir.coop.models import (
 from tapir.log.models import EmailLogEntry, LogEntry
 from tapir.log.util import freeze_for_log
 from tapir.log.views import UpdateViewLogMixin
-from tapir.settings import FROM_EMAIL_MEMBER_OFFICE, COOP_SHARE_PRICE
+from tapir.settings import FROM_EMAIL_MEMBER_OFFICE
 from tapir.shifts.models import (
     ShiftUserData,
     SHIFT_USER_CAPABILITY_CHOICES,

--- a/tapir/coop/views/statistics.py
+++ b/tapir/coop/views/statistics.py
@@ -7,13 +7,13 @@ from django.views import generic
 from django.views.generic import TemplateView
 
 from tapir.accounts.models import TapirUser
+from tapir.coop.config import COOP_SHARE_PRICE
 from tapir.coop.models import (
     ShareOwner,
     MemberStatus,
     DraftUser,
     ShareOwnership,
 )
-from tapir.settings import COOP_SHARE_PRICE
 
 
 class StatisticsView(PermissionRequiredMixin, generic.TemplateView):

--- a/tapir/coop/views/statistics.py
+++ b/tapir/coop/views/statistics.py
@@ -12,8 +12,8 @@ from tapir.coop.models import (
     MemberStatus,
     DraftUser,
     ShareOwnership,
-    COOP_SHARE_PRICE,
 )
+from tapir.settings import COOP_SHARE_PRICE
 
 
 class StatisticsView(PermissionRequiredMixin, generic.TemplateView):

--- a/tapir/settings.py
+++ b/tapir/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 import os
 import sys
+from decimal import Decimal
 from pathlib import Path
 
 import celery.schedules
@@ -243,3 +244,6 @@ if ENABLE_SILK_PROFILING:
     SILKY_PYTHON_PROFILER = True
     SILKY_PYTHON_PROFILER_BINARY = True
     SILKY_META = True
+
+COOP_SHARE_PRICE = Decimal(100)
+COOP_ENTRY_AMOUNT = Decimal(10)

--- a/tapir/settings.py
+++ b/tapir/settings.py
@@ -10,8 +10,6 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 import os
-import sys
-from decimal import Decimal
 from pathlib import Path
 
 import celery.schedules
@@ -244,6 +242,3 @@ if ENABLE_SILK_PROFILING:
     SILKY_PYTHON_PROFILER = True
     SILKY_PYTHON_PROFILER_BINARY = True
     SILKY_META = True
-
-COOP_SHARE_PRICE = Decimal(100)
-COOP_ENTRY_AMOUNT = Decimal(10)


### PR DESCRIPTION
I'd suggest to move share prices to `settings.py` to make them more transparently configurable for other coops.
Also I've fixed the mailchimp export. Is there a reason there is no link to that useful export utility?