### PR TITLE
Entry of annual calendar sidebar improved

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black

--- a/tapir/core/templatetags/core.py
+++ b/tapir/core/templatetags/core.py
@@ -78,7 +78,7 @@ def get_sidebar_link_groups(request):
     )
     shifts_group.add_link(
         display_name=_(
-            "ABCD weeks calendar, current week: {current_week_group_name}"
+            "ABCD annual calendar, current week: {current_week_group_name}"
         ).format(current_week_group_name=current_week_group_name),
         material_icon="table_view",
         url=reverse_lazy("shifts:shift_template_group_calendar"),

--- a/tapir/core/templatetags/core.py
+++ b/tapir/core/templatetags/core.py
@@ -77,7 +77,9 @@ def get_sidebar_link_groups(request):
         url=reverse_lazy("shifts:shift_template_overview"),
     )
     shifts_group.add_link(
-        display_name=_(f"ABCD weeks calendar, current week: {current_week_group_name}"),
+        display_name=_(
+            "ABCD weeks calendar, current week: {current_week_group_name}"
+        ).format(current_week_group_name=current_week_group_name),
         material_icon="table_view",
         url=reverse_lazy("shifts:shift_template_group_calendar"),
     )

--- a/tapir/translations/locale/de/LC_MESSAGES/django.po
+++ b/tapir/translations/locale/de/LC_MESSAGES/django.po
@@ -981,8 +981,8 @@ msgstr "ABCD-Schicht-Wochenplan"
 
 #: core/templatetags/core.py:80
 #, python-brace-format
-msgid "ABCD weeks calendar, current week: {current_week_group_name}"
-msgstr "ABCD-Wochenkalender\nAktuelle Woche: {current_week_group_name}"
+msgid "ABCD annual calendar, current week: {current_week_group_name}"
+msgstr "ABCD-Jahreskalender\nAktuelle Woche: {current_week_group_name}"
 
 #: core/templatetags/core.py:87
 #: shifts/templates/shifts/shift_calendar_past.html:6

--- a/tapir/translations/locale/de/LC_MESSAGES/django.po
+++ b/tapir/translations/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-05 19:07+0100\n"
+"POT-Creation-Date: 2022-04-24 20:05+0200\n"
 "PO-Revision-Date: 2022-03-05 19:07+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -26,21 +26,23 @@ msgstr "Nutzer*innenname"
 #: accounts/models.py:141
 msgid "Required. 150 characters or fewer. Letters, digits and ./-/_ only."
 msgstr ""
-"Erforderlich. Maximale Zeichenanzahl: 150. Bitte nur Buchstaben, Zahlen oder ./-/_ "
-"verwenden."
+"Erforderlich. Maximale Zeichenanzahl: 150. Bitte nur Buchstaben, Zahlen "
+"oder ./-/_ verwenden."
 
 #: accounts/models.py:145
 msgid "A user with that username already exists."
 msgstr "Es gibt bereits eine Nutzer*in mit diesem Namen."
 
-#: accounts/models.py:149 accounts/templates/accounts/user_detail.html:44 coop/models.py:50
-#: coop/models.py:258 coop/templates/coop/draftuser_detail.html:26
+#: accounts/models.py:149 accounts/templates/accounts/user_detail.html:44
+#: coop/models.py:50 coop/models.py:258
+#: coop/templates/coop/draftuser_detail.html:26
 #: coop/templates/coop/shareowner_detail.html:43
 msgid "Phone number"
 msgstr "Telefonnummer"
 
-#: accounts/models.py:150 accounts/templates/accounts/user_detail.html:54 coop/models.py:51
-#: coop/models.py:259 coop/templates/coop/draftuser_detail.html:30
+#: accounts/models.py:150 accounts/templates/accounts/user_detail.html:54
+#: coop/models.py:51 coop/models.py:259
+#: coop/templates/coop/draftuser_detail.html:30
 #: coop/templates/coop/shareowner_detail.html:47
 msgid "Birthdate"
 msgstr "Geburtsdatum"
@@ -65,8 +67,9 @@ msgstr "Ort"
 msgid "Country"
 msgstr "Land"
 
-#: accounts/models.py:158 accounts/templates/accounts/user_detail.html:74 coop/models.py:59
-#: coop/models.py:267 coop/templates/coop/shareowner_detail.html:67
+#: accounts/models.py:158 accounts/templates/accounts/user_detail.html:74
+#: coop/models.py:59 coop/models.py:267
+#: coop/templates/coop/shareowner_detail.html:67
 msgid "Preferred Language"
 msgstr "Bevorzugte Sprache"
 
@@ -80,10 +83,10 @@ msgid ""
 "\n"
 "    <p>Dear %(user_display_name)s,</p>\n"
 "    <p>\n"
-"        we've just created an account for you in our %(coop_name)s member system. Here you "
-"can view your upcoming shifts,\n"
-"        book an additional shift if you'd like or mark your shift as “looking for a stand-"
-"in” (for example when you go\n"
+"        we've just created an account for you in our %(coop_name)s member "
+"system. Here you can view your upcoming shifts,\n"
+"        book an additional shift if you'd like or mark your shift as "
+"“looking for a stand-in” (for example when you go\n"
 "        on vacation).\n"
 "    </p>\n"
 msgstr ""
@@ -93,20 +96,20 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"                Your regular ABCD-shift is: %(slot_display_name)s. You will receive a "
-"reminder email in advance of your first shift.\n"
+"                Your regular ABCD-shift is: %(slot_display_name)s. You will "
+"receive a reminder email in advance of your first shift.\n"
 "            "
 msgstr ""
 "\n"
-"Deine regelmäßige ABCD-Schicht ist: %(slot_display_name)s. Vor deiner ersten Schicht wirst "
-"du nochmal eine Erinnerungsmail erhalten.\n"
+"Deine regelmäßige ABCD-Schicht ist: %(slot_display_name)s. Vor deiner ersten "
+"Schicht wirst du nochmal eine Erinnerungsmail erhalten.\n"
 " "
 
 #: accounts/templates/accounts/email/welcome_email.default.html:26
 msgid ""
 "\n"
-"            Flying members: Please keep in mind that you must have at least one shift "
-"“banked” for each shift cycle.\n"
+"            Flying members: Please keep in mind that you must have at least "
+"one shift “banked” for each shift cycle.\n"
 "        "
 msgstr ""
 
@@ -114,12 +117,12 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"    <p>Your username is <strong>%(username)s</strong>. In order to log in to your account, "
-"you first have to set a password: <a href=\"%(site_url)s%(password_reset_confirm_url)s"
-"\">Click here to set your password</a></p>\n"
-"    <p>This link is only valid for a few weeks. Should it expire, you can get a new one "
-"here : <a href=\"%(site_url)s%(password_reset_request_url)s\">Click here to get a new "
-"link</a></p>\n"
+"    <p>Your username is <strong>%(username)s</strong>. In order to log in to "
+"your account, you first have to set a password: <a href=\"%(site_url)s"
+"%(password_reset_confirm_url)s\">Click here to set your password</a></p>\n"
+"    <p>This link is only valid for a few weeks. Should it expire, you can "
+"get a new one here : <a href=\"%(site_url)s%(password_reset_request_url)s"
+"\">Click here to get a new link</a></p>\n"
 "    "
 msgstr ""
 
@@ -132,62 +135,70 @@ msgstr "Willkommen"
 msgid ""
 "\n"
 "    <p>Dear %(user_display_name)s,</p>\n"
-"    <p>we just created an account for you in our SuperCoop member system. Here you can "
-"view your upcoming shifts, book an additional shift if you'd like or mark your shift as "
-"“looking for a stand-in” (for example when you go on vacation). <br/>\n"
-"        Please see the <a href=\"https://wiki.supercoop.de/wiki/Member_Manual\">Member "
-"Manual</a> section III for more information on the Stand-in System.</p>\n"
+"    <p>we just created an account for you in our SuperCoop member system. "
+"Here you can view your upcoming shifts, book an additional shift if you'd "
+"like or mark your shift as “looking for a stand-in” (for example when you go "
+"on vacation). <br/>\n"
+"        Please see the <a href=\"https://wiki.supercoop.de/wiki/Member_Manual"
+"\">Member Manual</a> section III for more information on the Stand-in System."
+"</p>\n"
 msgstr ""
 "\n"
 "<p> Liebe*r %(user_display_name)s,</p>\n"
-"<p>soeben haben wir für dich ein Konto in unserem SuperCoop Mitgliedersystem angelegt. "
-"Hier kannst du deine kommenden Schichten einsehen, dir nach Lust und Laune eine "
-"zusätzliche Schicht buchen oder eine deiner eigenen Schichten zur Neubesetzung freigeben, "
-"beispielsweise wenn du in den Urlaub fährst.<br />\n"
-"Mehr über Informationen über das Vertretungssystem findest du im <a href=\"https://wiki."
-"supercoop.de/wiki/Member_Manual\">Mitgliederhandbuch</a>.</p>\n"
+"<p>soeben haben wir für dich ein Konto in unserem SuperCoop Mitgliedersystem "
+"angelegt. Hier kannst du deine kommenden Schichten einsehen, dir nach Lust "
+"und Laune eine zusätzliche Schicht buchen oder eine deiner eigenen Schichten "
+"zur Neubesetzung freigeben, beispielsweise wenn du in den Urlaub fährst.<br /"
+">\n"
+"Mehr über Informationen über das Vertretungssystem findest du im <a href="
+"\"https://wiki.supercoop.de/wiki/Member_Manual\">Mitgliederhandbuch</a>.</"
+"p>\n"
 
 #: accounts/templates/accounts/email/welcome_email.html:24
 msgid ""
 "\n"
-"            Flying members: Please keep in mind that you must have at least one shift "
-"“banked” for each shift cycle. For more information please see the <a href=\"https://wiki."
-"supercoop.de/wiki/Member_Manual\">Member Manual</a> .\n"
+"            Flying members: Please keep in mind that you must have at least "
+"one shift “banked” for each shift cycle. For more information please see the "
+"<a href=\"https://wiki.supercoop.de/wiki/Member_Manual\">Member Manual</"
+"a> .\n"
 "        "
 msgstr ""
 "\n"
-"Fliegende Mitglieder: Bitte achtet darauf, zu jedem Zyklus-Ende mindestens ein "
-"Schichtguthaben auf eurem Schichtkonto zu haben. Mehr Infos findet ihr im <a href="
-"\"https://wiki.supercoop.de/wiki/Member_Manual\">Mitgliederhandbuch</a>.\n"
+"Fliegende Mitglieder: Bitte achtet darauf, zu jedem Zyklus-Ende mindestens "
+"ein Schichtguthaben auf eurem Schichtkonto zu haben. Mehr Infos findet ihr "
+"im <a href=\"https://wiki.supercoop.de/wiki/Member_Manual"
+"\">Mitgliederhandbuch</a>.\n"
 " "
 
 #: accounts/templates/accounts/email/welcome_email.html:33
 #, python-format
 msgid ""
 "\n"
-"        <p>Your username is *%(username)s* . In order to login to your account, you first "
-"have to set a password : <a href=\"%(site_url)s%(password_reset_confirm_url)s\">Click here "
-"to set your password</a></p>\n"
-"        <p>This link is only valid for a few weeks. Should it expire, you can get a new "
-"one here : <a href=\"%(site_url)s%(password_reset_request_url)s\">Click here to get a new "
-"link</a></p>\n"
+"        <p>Your username is *%(username)s* . In order to login to your "
+"account, you first have to set a password : <a href=\"%(site_url)s"
+"%(password_reset_confirm_url)s\">Click here to set your password</a></p>\n"
+"        <p>This link is only valid for a few weeks. Should it expire, you "
+"can get a new one here : <a href=\"%(site_url)s%(password_reset_request_url)s"
+"\">Click here to get a new link</a></p>\n"
 "        <p>You can also login to the SuperCoop wiki with that account.</p>\n"
-"        <p>Alternatively, as for any other question, you can always contact the <a href="
-"\"https://wiki.supercoop.de/wiki/Mitgliederb%%C3%%BCro_-_Member_Office\">Member Office</"
-"a></p>\n"
+"        <p>Alternatively, as for any other question, you can always contact "
+"the <a href=\"https://wiki.supercoop.de/wiki/Mitgliederb%%C3%%BCro_-"
+"_Member_Office\">Member Office</a></p>\n"
 "    "
 msgstr ""
 "\n"
-"<p>Dein Nutzer*innenname ist *%(username)s* . Um dein Konto nutzen zu können, musst du "
-"zuerst ein Passwort festlegen: <a href=\"%(site_url)s%(password_reset_confirm_url)s"
-"\">Klick hier um dein Passwort zu setzen.</a></p>\n"
-"<p>Dieser Link ist nur einige Wochen gültig. Sollte er abgelaufen sein, kannst du einen "
-"neuen Link anfordern: <a href=\"%(site_url)s%(password_reset_request_url)s\">Klick hier um "
-"einen neuen Link zu bekommen.</a></p>\n"
+"<p>Dein Nutzer*innenname ist *%(username)s* . Um dein Konto nutzen zu "
+"können, musst du zuerst ein Passwort festlegen: <a href=\"%(site_url)s"
+"%(password_reset_confirm_url)s\">Klick hier um dein Passwort zu setzen.</a></"
+"p>\n"
+"<p>Dieser Link ist nur einige Wochen gültig. Sollte er abgelaufen sein, "
+"kannst du einen neuen Link anfordern: <a href=\"%(site_url)s"
+"%(password_reset_request_url)s\">Klick hier um einen neuen Link zu bekommen."
+"</a></p>\n"
 "<p>Mit diesem Konto kannst du dich auch in unser Wiki einloggen.</p>\n"
-"<p>Alternativ, und auch bei allen anderen Fragen, kannst du dich jederzeit an das <a href="
-"\"https://wiki.supercoop.de/wiki/Mitgliederb%%C3%%BCro_-_Member_Office\">Mitgliederbüro</"
-"a> wenden.</p>\n"
+"<p>Alternativ, und auch bei allen anderen Fragen, kannst du dich jederzeit "
+"an das <a href=\"https://wiki.supercoop.de/wiki/Mitgliederb%%C3%%BCro_-"
+"_Member_Office\">Mitgliederbüro</a> wenden.</p>\n"
 " "
 
 #: accounts/templates/accounts/email/welcome_email.html:41
@@ -222,13 +233,15 @@ msgstr "Persönliche Daten"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: accounts/templates/accounts/user_detail.html:32 coop/models.py:329 coop/models.py:337
-#: coop/templates/coop/draftuser_detail.html:14 coop/templates/coop/shareowner_detail.html:35
+#: accounts/templates/accounts/user_detail.html:32 coop/models.py:329
+#: coop/models.py:337 coop/templates/coop/draftuser_detail.html:14
+#: coop/templates/coop/shareowner_detail.html:35
 msgid "Name"
 msgstr "Name"
 
 #: accounts/templates/accounts/user_detail.html:40
-#: coop/templates/coop/draftuser_detail.html:22 coop/templates/coop/draftuser_list.html:22
+#: coop/templates/coop/draftuser_detail.html:22
+#: coop/templates/coop/draftuser_list.html:22
 #: coop/templates/coop/shareowner_detail.html:39
 msgid "Email"
 msgstr "E-Mail-Adresse"
@@ -236,14 +249,16 @@ msgstr "E-Mail-Adresse"
 #: accounts/templates/accounts/user_detail.html:49
 #: accounts/templates/accounts/user_detail.html:59
 #: accounts/templates/accounts/user_detail.html:69
-#: coop/templates/coop/draftuser_detail.html:44 coop/templates/coop/shareowner_detail.html:52
+#: coop/templates/coop/draftuser_detail.html:44
+#: coop/templates/coop/shareowner_detail.html:52
 #: coop/templates/coop/shareowner_detail.html:62
 #: shifts/templates/shifts/user_shifts_overview_tag.html:60
 msgid "Missing"
 msgstr "Fehlend"
 
 #: accounts/templates/accounts/user_detail.html:64
-#: coop/templates/coop/draftuser_detail.html:39 coop/templates/coop/shareowner_detail.html:57
+#: coop/templates/coop/draftuser_detail.html:39
+#: coop/templates/coop/shareowner_detail.html:57
 msgid "Address"
 msgstr "Adresse"
 
@@ -271,7 +286,8 @@ msgstr "Nutzer*innen"
 #: coop/templates/coop/draftuser_register_form.html:51
 #: coop/templates/coop/financingcampaign_form.html:21
 #: coop/templates/coop/shareowner_form.html:21
-#: coop/templates/coop/shareownership_form.html:29 shifts/templates/shifts/shift_form.html:25
+#: coop/templates/coop/shareownership_form.html:29
+#: shifts/templates/shifts/shift_form.html:25
 #: shifts/templates/shifts/shiftaccountentry_form.html:21
 #: shifts/templates/shifts/shiftattendance_form.html:26
 #: shifts/templates/shifts/shiftexemption_form.html:26
@@ -292,8 +308,9 @@ msgid ""
 "        <p>\n"
 "            Someone asked for password reset for %(email)s.<br/>\n"
 "            Your username is %(username)s <br/>\n"
-"            Follow this link to reset your password: <a href=\"%(protocol)s://%(domain)s"
-"%(password_reset_url)s\">%(protocol)s://%(domain)s%(password_reset_url)s</a>\n"
+"            Follow this link to reset your password: <a href="
+"\"%(protocol)s://%(domain)s%(password_reset_url)s\">%(protocol)s://%(domain)s"
+"%(password_reset_url)s</a>\n"
 "        </p>\n"
 "    "
 msgstr ""
@@ -303,8 +320,9 @@ msgstr ""
 "    <p>\n"
 "        Jemand hat nach einem Passwort-Reset gefragt für %(email)s.<br/>\n"
 "        Deine Benutzername ist %(username)s <br/>\n"
-"        Folge diesem Link um dein Passwort zurückzusetzen: <a href=\"%(protocol)s://"
-"%(domain)s%(password_reset_url)s\">%(protocol)s://%(domain)s%(password_reset_url)s</a>\n"
+"        Folge diesem Link um dein Passwort zurückzusetzen: <a href="
+"\"%(protocol)s://%(domain)s%(password_reset_url)s\">%(protocol)s://%(domain)s"
+"%(password_reset_url)s</a>\n"
 "    </p>\n"
 " "
 
@@ -320,6 +338,10 @@ msgstr ""
 #: accounts/templates/registration/login.html:45
 msgid "Sign in"
 msgstr "Einloggen"
+
+#: accounts/templates/registration/login.html:33
+msgid "Click here to show/hide the password"
+msgstr ""
 
 #: accounts/templates/registration/login.html:41
 msgid "Forgot your password?"
@@ -352,11 +374,11 @@ msgstr "Passwort ändern"
 
 #: accounts/templates/registration/password_reset_confirm.html:22
 msgid ""
-"The password reset link was invalid, possibly because it has already been used. Please "
-"request a new password reset."
+"The password reset link was invalid, possibly because it has already been "
+"used. Please request a new password reset."
 msgstr ""
-"Der Link zum Zurücksetzen des Passworts ist ungültig. Eventuell wurde er bereits genutzt. "
-"Bitte fordere einen neuen Link an."
+"Der Link zum Zurücksetzen des Passworts ist ungültig. Eventuell wurde er "
+"bereits genutzt. Bitte fordere einen neuen Link an."
 
 #: accounts/templates/registration/password_reset_done.html:9
 msgid "Password reset instructions have been sent."
@@ -364,14 +386,15 @@ msgstr "Anleitung zum Passwort zurücksetzen wurde gesendet."
 
 #: accounts/templates/registration/password_reset_done.html:11
 msgid ""
-"We've emailed you instructions for setting your password, if an account exists with the "
-"email you entered. You should receive them shortly. If you don't receive an email, please "
-"make sure you've entered the address you registered with, and check your spam folder."
+"We've emailed you instructions for setting your password, if an account "
+"exists with the email you entered. You should receive them shortly. If you "
+"don't receive an email, please make sure you've entered the address you "
+"registered with, and check your spam folder."
 msgstr ""
-"Wir haben dir eine Anleitung geschickt, wie du ein neues Passwort für dein Konto festlegen "
-"kannst. Du solltest sie in Kürze erhalten. Wenn nicht, dann prüfe bitte, ob du auch die E-"
-"Mail-Adresse angegeben hast, mit der du dich registriert hast, und schau auch in deinem "
-"Spam-Ordner nach."
+"Wir haben dir eine Anleitung geschickt, wie du ein neues Passwort für dein "
+"Konto festlegen kannst. Du solltest sie in Kürze erhalten. Wenn nicht, dann "
+"prüfe bitte, ob du auch die E-Mail-Adresse angegeben hast, mit der du dich "
+"registriert hast, und schau auch in deinem Spam-Ordner nach."
 
 #: accounts/templates/registration/password_reset_form.html:11
 msgid "Problems with logging in?"
@@ -379,10 +402,11 @@ msgstr "Probleme beim Anmelden?"
 
 #: accounts/templates/registration/password_reset_form.html:16
 msgid ""
-"Please enter your email address, we will send you instructions to reset your password."
+"Please enter your email address, we will send you instructions to reset your "
+"password."
 msgstr ""
-"Bitte gib deine E-Mail-Adresse ein. Wir schicken dir dann eine Anleitung, wie du dein "
-"Passwort zurücksetzen kannst."
+"Bitte gib deine E-Mail-Adresse ein. Wir schicken dir dann eine Anleitung, "
+"wie du dein Passwort zurücksetzen kannst."
 
 #: accounts/templates/registration/password_reset_form.html:19
 msgid "Back to login form"
@@ -394,16 +418,17 @@ msgstr "Schickt mir eine Anleitung!"
 
 #: accounts/validators.py:11
 msgid ""
-"Enter a valid username. This value may contain only letters, numbers, and ./-/_ characters."
+"Enter a valid username. This value may contain only letters, numbers, "
+"and ./-/_ characters."
 msgstr ""
-"Der angegebene Name ist ungültig. Er darf nur Buchstaben, Zahlen und die Symbole ./-/_ "
-"enthalten."
+"Der angegebene Name ist ungültig. Er darf nur Buchstaben, Zahlen und die "
+"Symbole ./-/_ enthalten."
 
 #: accounts/views.py:88
 msgid "Account welcome email sent."
 msgstr "Willkommens-E-Mail für Nutzer'*innenkonto gesendet."
 
-#: coop/forms.py:69 coop/views/shareowner.py:232
+#: coop/forms.py:71 coop/views/shareowner.py:232
 #, python-format
 msgid "Welcome at %(organisation_name)s!"
 msgstr "Willkommen in der %(organisation_name)s!"
@@ -412,11 +437,13 @@ msgstr "Willkommen in der %(organisation_name)s!"
 msgid "Is company"
 msgstr "Ist eine Firma"
 
-#: coop/models.py:47 coop/models.py:255 coop/templates/coop/draftuser_list.html:20
+#: coop/models.py:47 coop/models.py:255
+#: coop/templates/coop/draftuser_list.html:20
 msgid "First name"
 msgstr "Vorname"
 
-#: coop/models.py:48 coop/models.py:256 coop/templates/coop/draftuser_list.html:21
+#: coop/models.py:48 coop/models.py:256
+#: coop/templates/coop/draftuser_list.html:21
 msgid "Last name"
 msgstr "Nachname"
 
@@ -428,7 +455,8 @@ msgstr "E-Mail-Adresse"
 msgid "Is investing member"
 msgstr "Ist investierendes Mitglied"
 
-#: coop/models.py:68 coop/models.py:288 coop/templates/coop/draftuser_detail.html:61
+#: coop/models.py:68 coop/models.py:288
+#: coop/templates/coop/draftuser_detail.html:61
 #: coop/templates/coop/user_coop_share_ownership_list_tag.html:44
 #: coop/templates/coop/user_coop_share_ownership_list_tag.html:159
 msgid "Ratenzahlung"
@@ -438,7 +466,8 @@ msgstr "Ratenzahlung"
 msgid "Attended Welcome Session"
 msgstr "An Willkommenstreffen teilgenommen"
 
-#: coop/models.py:72 coop/models.py:285 coop/templates/coop/draftuser_detail.html:117
+#: coop/models.py:72 coop/models.py:285
+#: coop/templates/coop/draftuser_detail.html:117
 #: coop/templates/coop/user_coop_share_ownership_list_tag.html:154
 msgid "Paid Entrance Fee"
 msgstr "Eintrittsgeld bezahlt"
@@ -455,7 +484,8 @@ msgstr "Kann keine Firma sein und ein Tapir-Konto haben"
 msgid "User info should be stored in associated Tapir account"
 msgstr "Benutzer Infos sollen in dem Tapir Konto gespeichert warden"
 
-#: coop/models.py:199 coop/templates/coop/user_coop_share_ownership_list_tag.html:100
+#: coop/models.py:199
+#: coop/templates/coop/user_coop_share_ownership_list_tag.html:100
 msgid "Sold"
 msgstr "Verkauft"
 
@@ -475,7 +505,9 @@ msgstr "Der Betrag kann nicht negative sein"
 
 #: coop/models.py:244
 #, python-brace-format
-msgid "Amount paid for a share can't more than {COOP_SHARE_PRICE} (the price of a share)"
+msgid ""
+"Amount paid for a share can't more than {COOP_SHARE_PRICE} (the price of a "
+"share)"
 msgstr "Der Betrag kann nicht mehr als {COOP_SHARE_PRICE} sein"
 
 #: coop/models.py:273
@@ -531,24 +563,28 @@ msgstr "Anmeldung bestätigt"
 msgid ""
 "\n"
 "            <p>Registration successful! Congratulations!</p>\n"
-"            <p>We just emailed your confirmation of your pre-registration with the "
-"Beteiligungserklärung already filled with your information. You just have to print it and "
-"send it back to us per post or scan it and send it per email.</p>\n"
-"            <p>Once we have received both your Beteiligungserklärung and the corresponding "
-"payment, we'll send you the confirmation of your membership.</p>\n"
-"            <p>We will also create for you an account for this website and for the wiki.</"
+"            <p>We just emailed your confirmation of your pre-registration "
+"with the Beteiligungserklärung already filled with your information. You "
+"just have to print it and send it back to us per post or scan it and send it "
+"per email.</p>\n"
+"            <p>Once we have received both your Beteiligungserklärung and the "
+"corresponding payment, we'll send you the confirmation of your membership.</"
 "p>\n"
+"            <p>We will also create for you an account for this website and "
+"for the wiki.</p>\n"
 "            "
 msgstr ""
 "\n"
 "            <p>Anmeldung erflogreich! Congratulations!</p>\n"
-"            <p>We just emailed your confirmation of your pre-registration with the "
-"Beteiligungserklärung already filled with your information. You just have to print it and "
-"send it back to us per post or scan it and send it per email.</p>\n"
-"            <p>Once we have received both your Beteiligungserklärung and the corresponding "
-"payment, we'll send you the confirmation of your membership.</p>\n"
-"            <p>We will also create for you an account for this website and for the wiki.</"
+"            <p>We just emailed your confirmation of your pre-registration "
+"with the Beteiligungserklärung already filled with your information. You "
+"just have to print it and send it back to us per post or scan it and send it "
+"per email.</p>\n"
+"            <p>Once we have received both your Beteiligungserklärung and the "
+"corresponding payment, we'll send you the confirmation of your membership.</"
 "p>\n"
+"            <p>We will also create for you an account for this website and "
+"for the wiki.</p>\n"
 "            "
 
 #: coop/templates/coop/draftuser_detail.html:11
@@ -568,7 +604,8 @@ msgstr "Angeforderte Anteile"
 msgid "Welcome Session"
 msgstr "Willkommenstreffen"
 
-#: coop/templates/coop/draftuser_detail.html:89 coop/templates/coop/draftuser_list.html:23
+#: coop/templates/coop/draftuser_detail.html:89
+#: coop/templates/coop/draftuser_list.html:23
 msgid "Beteiligungserklärung"
 msgstr "Beteiligungserklärung"
 
@@ -611,11 +648,10 @@ msgstr "Bewerber*in erzeugen"
 
 #: coop/templates/coop/draftuser_register_form.default.html:37
 #: coop/templates/coop/draftuser_register_form.html:37
-#: shifts/templates/shifts/shift_template_detail.html:80
-#: shifts/templates/shifts/slot_register.html:23
-#: shifts/templates/shifts/slot_register.html:39
-#: shifts/templates/shifts/slot_template_register.html:23
-#: shifts/templates/shifts/slot_template_register.html:39
+#: shifts/templates/shifts/register_user_to_shift_slot.html:32
+#: shifts/templates/shifts/register_user_to_shift_slot_template.html:25
+#: shifts/templates/shifts/shift_detail.html:181
+#: shifts/templates/shifts/shift_template_detail.html:72
 msgid "Register"
 msgstr "Anmelden"
 
@@ -630,8 +666,9 @@ msgstr ""
 #: coop/templates/coop/matching_program.html:21
 msgid ""
 "\n"
-"                    The members in this list have expressed that they are willing to pay "
-"the share for a potential new member that otherwise couldn't afford it.\n"
+"                    The members in this list have expressed that they are "
+"willing to pay the share for a potential new member that otherwise couldn't "
+"afford it.\n"
 "                "
 msgstr ""
 
@@ -648,6 +685,7 @@ msgid "Cooperative Members"
 msgstr "Genossenschaftsmitglieder"
 
 #: coop/templates/coop/shareowner_list.html:22
+#: shifts/templates/shifts/members_on_alert_list.html:18
 msgid "Export"
 msgstr "Exportieren"
 
@@ -659,12 +697,13 @@ msgstr "Alle Filter entfernen"
 #, python-format
 msgid ""
 "\n"
-"                            Filtered %(filtered_member_count)s of %(total_member_count)s\n"
+"                            Filtered %(filtered_member_count)s of "
+"%(total_member_count)s\n"
 "                            "
 msgstr ""
 "\n"
-"                            %(filtered_member_count)s aus %(total_member_count)s "
-"gefilterte Mitglieder\n"
+"                            %(filtered_member_count)s aus "
+"%(total_member_count)s gefilterte Mitglieder\n"
 "                            "
 
 #: coop/templates/coop/shop_extension_progress_bar.html:4
@@ -715,7 +754,8 @@ msgid "Membership confirmation"
 msgstr "Mitgliedsbestätigung"
 
 #: coop/templates/coop/user_coop_share_ownership_list_tag.html:28
-#: coop/views/shareowner.py:383 shifts/templates/shifts/user_shifts_overview_tag.html:17
+#: coop/views/shareowner.py:383
+#: shifts/templates/shifts/user_shifts_overview_tag.html:17
 msgid "Status"
 msgstr "Status"
 
@@ -723,14 +763,15 @@ msgstr "Status"
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: coop/templates/coop/user_coop_share_ownership_list_tag.html:53 shifts/models.py:777
-#: shifts/templates/shifts/shift_day_printable.html:56
-#: shifts/templates/shifts/shift_detail.html:205
+#: coop/templates/coop/user_coop_share_ownership_list_tag.html:53
+#: shifts/models.py:878 shifts/templates/shifts/shift_day_printable.html:56
+#: shifts/templates/shifts/shift_detail.html:200
 #: shifts/templates/shifts/shift_detail_printable.html:48
 msgid "Attended"
 msgstr "Teilgenommen"
 
-#: coop/templates/coop/user_coop_share_ownership_list_tag.html:55 shifts/models.py:776
+#: coop/templates/coop/user_coop_share_ownership_list_tag.html:55
+#: shifts/models.py:877
 msgid "Pending"
 msgstr "Ausstehend"
 
@@ -757,21 +798,22 @@ msgstr "Löschen"
 #: coop/templates/coop/user_coop_share_ownership_list_tag.html:125
 msgid ""
 "\n"
-"                                                        Only use this to correct mistakes, "
-"i.e. if the share was\n"
+"                                                        Only use this to "
+"correct mistakes, i.e. if the share was\n"
 "                                                        erroneously\n"
-"                                                        entered into the system and the "
-"person never actually\n"
-"                                                        bought it. If the person simply "
-"sold their share back to the\n"
-"                                                        coop, please mark the share as "
-"sold instead.\n"
+"                                                        entered into the "
+"system and the person never actually\n"
+"                                                        bought it. If the "
+"person simply sold their share back to the\n"
+"                                                        coop, please mark "
+"the share as sold instead.\n"
 "                                                    "
 msgstr ""
 "\n"
-"Bitte nur verwenden, wenn ein tatsächlicher Fehler vorliegt, z.B. ein Anteil eingetragen "
-"wurde, der nie gekauft wurde. Wenn die Person ihren Anteil einfach an den Coop "
-"zurückverkauft hat, markiere den Anteil bitte als 'verkauft'.\n"
+"Bitte nur verwenden, wenn ein tatsächlicher Fehler vorliegt, z.B. ein Anteil "
+"eingetragen wurde, der nie gekauft wurde. Wenn die Person ihren Anteil "
+"einfach an den Coop zurückverkauft hat, markiere den Anteil bitte als "
+"'verkauft'.\n"
 " "
 
 #: coop/templates/coop/user_coop_share_ownership_list_tag.html:147
@@ -796,39 +838,74 @@ msgid "Welcome Desk"
 msgstr "Welcome Desk"
 
 #: coop/templates/coop/welcome_desk_share_owner.html:25
-#, python-format
-msgid "%(name)s  can shop :)"
+#, fuzzy, python-format
+#| msgid "%(name)s  can shop :)"
+msgid ""
+"%(name)s  can shop\n"
+"                        :)"
 msgstr "%(name)s kann einkaufen :)"
 
-#: coop/templates/coop/welcome_desk_share_owner.html:30
-#, python-format
-msgid "%(name)s does not have a Tapir account. Contact a member of the management team."
-msgstr "%(name)s hat kein Tapir-Konto. Kontaktiere eine Person aus dem Vorstand."
-
-#: coop/templates/coop/welcome_desk_share_owner.html:35
-#, python-format
-msgid "%(name)s has a negative shift balance. Contact a member of the management team."
-msgstr "%(name)s hat ein negatives Schicht-Score. Kontaktiere eine Person aus dem Vorstand."
-
-#: coop/templates/coop/welcome_desk_share_owner.html:40
-#, python-format
+#: coop/templates/coop/welcome_desk_share_owner.html:31
+#, fuzzy, python-format
+#| msgid ""
+#| "%(name)s does not have a Tapir account. Contact a member of the "
+#| "management team."
 msgid ""
-"%(name)s is an investing member. If they want to shop, they have to become an active "
-"member. Contact a member of the management team."
+"%(name)s does not have a Tapir\n"
+"                            account. Contact a member of the management team."
 msgstr ""
-"%(name)s ist ein investierendes Mitglied. Um einkaufen zu könne, müssen sie ein aktiv "
-"Mitglied werden. Kontaktiere eine Person aus dem Vorstand."
+"%(name)s hat kein Tapir-Konto. Kontaktiere eine Person aus dem Vorstand."
 
-#: coop/templates/coop/welcome_desk_share_owner.html:46
-#, python-format
-msgid "%(name)s is not registered to an ABCD shift yet. Make sure they plan to do it!"
-msgstr "%(name)s is noch zu keiner ABCD Schicht angemeldet. Er/Sie soll es planen!"
-
-#: coop/templates/coop/welcome_desk_share_owner.html:51
-#, python-format
-msgid "%(name)s has not attended a welcome session yet. Make sure they plan to do it!"
+#: coop/templates/coop/welcome_desk_share_owner.html:37
+#, fuzzy, python-format
+#| msgid ""
+#| "%(name)s has a negative shift balance. Contact a member of the management "
+#| "team."
+msgid ""
+"\n"
+"                            %(name)s has a negative shift balance "
+"(%(balance)s). Contact a member of the management\n"
+"                            team."
 msgstr ""
-"%(name)s hat an das Willkommenstreffen noch nicht teilgenommen. Er/Sie soll es planen!"
+"%(name)s hat ein negatives Schicht-Score. Kontaktiere eine Person aus dem "
+"Vorstand."
+
+#: coop/templates/coop/welcome_desk_share_owner.html:44
+#, fuzzy, python-format
+#| msgid ""
+#| "%(name)s is an investing member. If they want to shop, they have to "
+#| "become an active member. Contact a member of the management team."
+msgid ""
+"%(name)s is an investing member.\n"
+"                            If they want to shop, they have to become an "
+"active member. Contact a member of the\n"
+"                            management team."
+msgstr ""
+"%(name)s ist ein investierendes Mitglied. Um einkaufen zu könne, müssen sie "
+"ein aktiv Mitglied werden. Kontaktiere eine Person aus dem Vorstand."
+
+#: coop/templates/coop/welcome_desk_share_owner.html:52
+#, fuzzy, python-format
+#| msgid ""
+#| "%(name)s is not registered to an ABCD shift yet. Make sure they plan to "
+#| "do it!"
+msgid ""
+"%(name)s is not registered to an\n"
+"                        ABCD shift yet. Make sure they plan to do it!"
+msgstr ""
+"%(name)s is noch zu keiner ABCD Schicht angemeldet. Er/Sie soll es planen!"
+
+#: coop/templates/coop/welcome_desk_share_owner.html:58
+#, fuzzy, python-format
+#| msgid ""
+#| "%(name)s has not attended a welcome session yet. Make sure they plan to "
+#| "do it!"
+msgid ""
+"%(name)s has not attended a welcome\n"
+"                        session yet. Make sure they plan to do it!"
+msgstr ""
+"%(name)s hat an das Willkommenstreffen noch nicht teilgenommen. Er/Sie soll "
+"es planen!"
 
 #: coop/views/shareowner.py:259
 msgid "Welcome email with membership confirmation sent."
@@ -838,7 +915,8 @@ msgstr "Mitgliedsbestätigung per Mail gesendet."
 msgid "Any"
 msgstr "Alle"
 
-#: coop/views/shareowner.py:389 shifts/templates/shifts/user_shifts_overview_tag.html:107
+#: coop/views/shareowner.py:389
+#: shifts/templates/shifts/user_shifts_overview_tag.html:107
 msgid "Shift Status"
 msgstr "Schichtstatus"
 
@@ -887,12 +965,13 @@ msgstr ""
 msgid "Statistics"
 msgstr "Statistik"
 
-#: core/templatetags/core.py:67 shifts/templates/shifts/shift_template_detail.html:34
+#: core/templatetags/core.py:67
 #: shifts/templates/shifts/user_shifts_overview_tag.html:6
 msgid "Shifts"
 msgstr "Schichten"
 
-#: core/templatetags/core.py:70 shifts/templates/shifts/shift_calendar_future.html:6
+#: core/templatetags/core.py:70
+#: shifts/templates/shifts/shift_calendar_future.html:6
 msgid "Shift calendar"
 msgstr "Schicht-Kalender"
 
@@ -903,13 +982,15 @@ msgstr "ABCD-Schicht-Wochenplan"
 #: core/templatetags/core.py:80
 #, python-brace-format
 msgid "ABCD weeks calendar, current week: {current_week_group_name}"
-msgstr "ABCD-Wochenkalender<br />Aktuelle Woche: {current_week_group_name}"
+msgstr "ABCD-Wochenkalender\nAktuelle Woche: {current_week_group_name}"
 
-#: core/templatetags/core.py:87 shifts/templates/shifts/shift_calendar_past.html:6
+#: core/templatetags/core.py:87
+#: shifts/templates/shifts/shift_calendar_past.html:6
 msgid "Past shifts"
 msgstr "Vergangene Schichten"
 
-#: core/templatetags/core.py:92 shifts/templates/shifts/shiftexemption_list.html:8
+#: core/templatetags/core.py:92
+#: shifts/templates/shifts/shiftexemption_list.html:8
 msgid "Shift exemptions"
 msgstr "Schicht-Befreiungen"
 
@@ -917,31 +998,38 @@ msgstr "Schicht-Befreiungen"
 msgid "Shift statistics"
 msgstr "Schicht-Statistiken"
 
-#: core/templatetags/core.py:103
+#: core/templatetags/core.py:102
+#: shifts/templates/shifts/members_on_alert_list.html:14
+#, fuzzy
+#| msgid "Member manual"
+msgid "Members on alert"
+msgstr "Mitgliederhandbuch"
+
+#: core/templatetags/core.py:108
 msgid "Financing campaign"
 msgstr "Finanzierungskampagne"
 
-#: core/templatetags/core.py:112
+#: core/templatetags/core.py:117
 msgid "Miscellaneous"
 msgstr "Sonstiges"
 
-#: core/templatetags/core.py:115
+#: core/templatetags/core.py:120
 msgid "Wiki"
 msgstr "Wiki"
 
-#: core/templatetags/core.py:120
+#: core/templatetags/core.py:125
 msgid "Member manual"
 msgstr "Mitgliederhandbuch"
 
-#: core/templatetags/core.py:125
+#: core/templatetags/core.py:130
 msgid "Shop opening hours"
 msgstr "Öffnungszeiten"
 
-#: core/templatetags/core.py:130
+#: core/templatetags/core.py:135
 msgid "Contact the member office"
 msgstr "Mitgliederbüro kontaktieren"
 
-#: core/templatetags/core.py:135
+#: core/templatetags/core.py:140
 msgid "About tapir"
 msgstr "Über Tapir"
 
@@ -953,25 +1041,25 @@ msgstr "Erstellungsdatum"
 msgid "Log"
 msgstr "Protokoll"
 
-#: log/templates/log/log_entry_list_tag.html:12
+#: log/templates/log/log_entry_list_tag.html:11
 msgid "List of log entries for this user"
 msgstr "List der Protokoll-Einträge für dieses Mitglied"
 
-#: log/templates/log/log_entry_list_tag.html:40
+#: log/templates/log/log_entry_list_tag.html:39
 msgid "Notes about this user"
 msgstr "Notizen über diese*n Benutzer*in"
 
-#: log/templates/log/log_entry_list_tag.html:43
+#: log/templates/log/log_entry_list_tag.html:42
 msgid "Add Note"
 msgstr "Notiz hinzufügen"
 
-#: shifts/forms.py:49
+#: shifts/forms.py:50
 msgid ""
-"I have read the warning about the missing qualification and confirm that the user should "
-"get registered to the shift"
+"I have read the warning about the missing qualification and confirm that the "
+"user should get registered to the shift"
 msgstr ""
-"Ich habe die Warnung über die fehlende Befähigung gelesen und bestätige, dass Benutzer*in "
-"für die Schicht registriert werden sollte"
+"Ich habe die Warnung über die fehlende Befähigung gelesen und bestätige, "
+"dass Benutzer*in für die Schicht registriert werden sollte"
 
 #: shifts/forms.py:73
 #, python-brace-format
@@ -979,160 +1067,192 @@ msgid ""
 "The selected user is missing the required qualification for this shift : "
 "{missing_capabilities}"
 msgstr ""
-"Ausgewählte Nutzer*in hat nicht die erforderliche Befähigung für diese Schicht: "
-"{missing_capabilities}"
+"Ausgewählte Nutzer*in hat nicht die erforderliche Befähigung für diese "
+"Schicht: {missing_capabilities}"
 
-#: shifts/forms.py:102
+#: shifts/forms.py:107
 msgid "This user is already registered to another slot in this ABCD shift."
 msgstr ""
-"Diese*r Nutzer*in ist bereits für einen anderen Platz in dieser ABCD-Schicht registriert."
+"Diese*r Nutzer*in ist bereits für einen anderen Platz in dieser ABCD-Schicht "
+"registriert."
 
-#: shifts/forms.py:128
+#: shifts/forms.py:143
+msgid "You need the shifts.manage permission to do this."
+msgstr ""
+
+#: shifts/forms.py:147
 msgid "This user is already registered to another slot in this shift."
-msgstr "Diese*r Nutzer*in ist bereits für einen anderen Platz in dieser Schicht registriert."
+msgstr ""
+"Diese*r Nutzer*in ist bereits für einen anderen Platz in dieser Schicht "
+"registriert."
 
-#: shifts/forms.py:142 shifts/templates/shifts/user_shifts_overview_tag.html:128
+#: shifts/forms.py:158
+#: shifts/templates/shifts/user_shifts_overview_tag.html:128
 msgid "Qualifications"
 msgstr "Befähigungen"
 
-#: shifts/forms.py:183
+#: shifts/forms.py:199
 msgid ""
-"I have read the warning about the cancelled attendances and confirm that the exemption "
-"should be created"
-msgstr ""
-"Ich habe die Warnung über die Abgesagte Schicht-Anwesenheiten und bestätige das die "
-"Befreigung erzeugt warden soll"
-
-#: shifts/forms.py:190
-msgid ""
-"I have read the warning about the cancelled ABCD attendances and confirm that the "
+"I have read the warning about the cancelled attendances and confirm that the "
 "exemption should be created"
 msgstr ""
-"Ich habe die Warnung über die abgesagte ABCD-Schicht-Befreiungen gelesen und bestätige das "
-"die Befreiung erzeugt werden soll"
+"Ich habe die Warnung über die Abgesagte Schicht-Anwesenheiten und bestätige "
+"das die Befreigung erzeugt warden soll"
 
-#: shifts/forms.py:223
+#: shifts/forms.py:206
+msgid ""
+"I have read the warning about the cancelled ABCD attendances and confirm "
+"that the exemption should be created"
+msgstr ""
+"Ich habe die Warnung über die abgesagte ABCD-Schicht-Befreiungen gelesen und "
+"bestätige das die Befreiung erzeugt werden soll"
+
+#: shifts/forms.py:239
 #, python-brace-format
 msgid ""
-"The member will be unregistered from the following shifts because they are within the "
-"range of the exemption : {attendances_display}"
+"The member will be unregistered from the following shifts because they are "
+"within the range of the exemption : {attendances_display}"
 msgstr ""
-"Das Mitglied wird abgemeldet von der folgende Schichten weil die innerhalb der Befreiung "
-"sind : {attendances_display}"
+"Das Mitglied wird abgemeldet von der folgende Schichten weil die innerhalb "
+"der Befreiung sind : {attendances_display}"
 
-#: shifts/forms.py:248
+#: shifts/forms.py:264
 #, python-brace-format
 msgid ""
-"The user will be unregistered from the following ABCD shifts because the exemption is "
-"longer than {ShiftExemption.THRESHOLD_NB_CYCLES_UNREGISTER_FROM_ABCD_SHIFT} cycles: "
-"{attendances_display}"
+"The user will be unregistered from the following ABCD shifts because the "
+"exemption is longer than {ShiftExemption."
+"THRESHOLD_NB_CYCLES_UNREGISTER_FROM_ABCD_SHIFT} cycles: {attendances_display}"
 msgstr ""
-"Das Mitglierd wird von die folgende ABCD-Schichten abgemeldet weil die Befreiung länger "
-"als  {ShiftExemption.THRESHOLD_NB_CYCLES_UNREGISTER_FROM_ABCD_SHIFT} Zyklen: "
-"{attendances_display}"
+"Das Mitglierd wird von die folgende ABCD-Schichten abgemeldet weil die "
+"Befreiung länger als  {ShiftExemption."
+"THRESHOLD_NB_CYCLES_UNREGISTER_FROM_ABCD_SHIFT} Zyklen: {attendances_display}"
 
-#: shifts/models.py:34
+#: shifts/models.py:35
 msgid "Teamleader"
 msgstr "Teamleiter*in"
 
-#: shifts/models.py:35
+#: shifts/models.py:36
 msgid "Cashier"
 msgstr "Kasse"
 
-#: shifts/models.py:36
+#: shifts/models.py:37
 msgid "Member Office"
 msgstr "Mitgliederbüro"
 
-#: shifts/models.py:37
+#: shifts/models.py:38
 msgid "Bread Delivery"
 msgstr "Brotlieferung"
 
-#: shifts/models.py:38
+#: shifts/models.py:39
 msgid "Red Card"
 msgstr "Rote Karte Lebensmittel"
 
-#: shifts/models.py:39
+#: shifts/models.py:40
 msgid "First Aid"
 msgstr "Erste Hilfe"
 
-#: shifts/models.py:84
-msgid "Monday"
-msgstr "Montag"
+#: shifts/models.py:54
+msgid ""
+"I understand that all working groups help the Warenannahme & Lagerhaltung "
+"working group until the shop opens."
+msgstr ""
 
-#: shifts/models.py:85
-msgid "Tuesday"
-msgstr "Dienstag"
+#: shifts/models.py:57
+msgid ""
+"I understand that all working groups help the Reinigung & Aufräumen working "
+"group after the shop closes."
+msgstr ""
 
-#: shifts/models.py:86
-msgid "Wednesday"
-msgstr "Mittwoch"
+#: shifts/models.py:60
+msgid ""
+"I understand that I need my own vehicle in order to pick up the bread. A "
+"cargo bike can be borrowed, more infos in Slack in the #cargobike channel"
+msgstr ""
 
-#: shifts/models.py:87
-msgid "Thursday"
-msgstr "Donnerstag"
+#: shifts/models.py:63
+msgid "I understand that I may need to carry heavy weights for this shift."
+msgstr ""
 
-#: shifts/models.py:88
-msgid "Friday"
-msgstr "Freitag"
+#: shifts/models.py:66
+msgid ""
+"I understand that I may need to work high, for example up a ladder. I do not "
+"suffer from fear of heigts."
+msgstr ""
 
-#: shifts/models.py:89
-msgid "Saturday"
-msgstr "Samstag"
-
-#: shifts/models.py:90
-msgid "Sunday"
-msgstr "Sonntag"
-
-#: shifts/models.py:666
+#: shifts/models.py:737
 msgid "You found a stand-in!"
 msgstr "Vertretung gefunden!"
 
-#: shifts/models.py:778 shifts/templates/shifts/shift_day_printable.html:57
-#: shifts/templates/shifts/shift_detail.html:215
+#: shifts/models.py:879 shifts/templates/shifts/shift_day_printable.html:57
+#: shifts/templates/shifts/shift_detail.html:210
 #: shifts/templates/shifts/shift_detail_printable.html:49
 msgid "Missed"
 msgstr "Nicht erschienen"
 
-#: shifts/models.py:779 shifts/templates/shifts/shift_day_printable.html:58
-#: shifts/templates/shifts/shift_detail.html:245
+#: shifts/models.py:880 shifts/templates/shifts/shift_day_printable.html:58
+#: shifts/templates/shifts/shift_detail.html:240
 #: shifts/templates/shifts/shift_detail_printable.html:50
 msgid "Excused"
 msgstr "Entschuldigt"
 
-#: shifts/models.py:780 shifts/templates/shifts/shift_detail.html:253
+#: shifts/models.py:881 shifts/templates/shifts/shift_detail.html:248
 msgid "Cancelled"
 msgstr "Abgesagt"
 
-#: shifts/models.py:781 shifts/templates/shifts/shift_detail.html:237
-#: shifts/templates/shifts/shift_filters.html:55
+#: shifts/models.py:882 shifts/templates/shifts/shift_detail.html:232
+#: shifts/templates/shifts/shift_filters.html:57
 msgid "Looking for a stand-in"
 msgstr "Sucht Vertretung"
 
-#: shifts/models.py:821
+#: shifts/models.py:922
 msgid "🏠 ABCD"
 msgstr "🏠 ABCD"
 
-#: shifts/models.py:822
+#: shifts/models.py:923
 msgid "✈ Flying"
 msgstr "✈ Fliegend"
 
-#: shifts/models.py:825
+#: shifts/models.py:926
 msgid "Shift system"
 msgstr "Schichten"
 
-#: shifts/models.py:890
+#: shifts/models.py:991
 #, python-format
 msgid "Your upcoming %(coop_name)s shift: %(shift)s"
 msgstr "Deine nächste %(coop_name)s Schicht: %(shift)s"
 
-#: shifts/models.py:940 shifts/templates/shifts/shiftexemption_list.html:22
+#: shifts/models.py:1046 shifts/templates/shifts/shiftexemption_list.html:22
 #: shifts/templates/shifts/user_shift_account_log.html:28
 msgid "Description"
 msgstr "Beschreibung"
 
-#: shifts/models.py:1006
+#: shifts/models.py:1114
 msgid "Cycle start date"
 msgstr "Anfangsdatum"
+
+#: shifts/templates/shifts/cancel_shift.html:11
+msgid "Cancel shift:"
+msgstr ""
+
+#: shifts/templates/shifts/cancel_shift.html:15
+msgid ""
+"\n"
+"                        Cancelling a shift is used for example for holidays. "
+"It has the following consequences :\n"
+"                        <ul>\n"
+"                            <li>It is not possible to register to the shift "
+"anymore.</li>\n"
+"                            <li>Members who are registered from their ABCD "
+"shift get a shift point.</li>\n"
+"                            <li>Members who registered just to this shift "
+"don't get a point.</li>\n"
+"                        </ul>\n"
+"                    "
+msgstr ""
+
+#: shifts/templates/shifts/cancel_shift.html:30
+msgid "Confirm cancellation"
+msgstr ""
 
 #: shifts/templates/shifts/email/shift_missed.default.html:7
 #: shifts/templates/shifts/email/shift_missed.html:7
@@ -1148,11 +1268,11 @@ msgid ""
 "<p>This is an automated email from %(coop_name)s.</p>\n"
 "\n"
 "    <p>\n"
-"        It has been registered in the %(coop_name)s shift system that you didn't attend "
-"the following shift which you had registered for:\n"
+"        It has been registered in the %(coop_name)s shift system that you "
+"didn't attend the following shift which you had registered for:\n"
 "        %(shift_display_name)s <br/>\n"
-"        If it's a mistake, or you think that you should be excused from this shift, please "
-"contact the member office: %(contact_email_address)s .<br/>\n"
+"        If it's a mistake, or you think that you should be excused from this "
+"shift, please contact the member office: %(contact_email_address)s .<br/>\n"
 "    </p>\n"
 msgstr ""
 
@@ -1165,19 +1285,20 @@ msgid ""
 "    <p>This is an automated email from SuperCoop.</p>\n"
 "\n"
 "    <p>\n"
-"        It has been registered in the Tapir system that you didn't attend the following "
-"shift which you had registered for:\n"
+"        It has been registered in the Tapir system that you didn't attend "
+"the following shift which you had registered for:\n"
 "        %(shift_display_name)s <br/>\n"
-"        If it's a mistake, or you think that you should be excused from this shift, please "
-"contact the member office: mitglied@supercoop.de .<br/>\n"
-"        As stated in the Member Manual, a missed shift must be compensated for by "
-"completing 2 make-up shifts within four weeks of your missed shift. You can schedule your "
-"make-up shifts directly on <a href=\"https://members.supercoop.de/shifts/timetable"
-"\">Tapir</a>.<br/>\n"
-"        Please keep in mind that if you do not complete your make-up shifts your shopping "
-"and voting rights will be suspended. For more information please see the <a href=\"https://"
-"docs.google.com/document/d/19v91mj2MAJTtrPLCw54VMS6qlaiJqBqUAuiC6z_AKpw/edit#heading=h."
-"lk042ux0tm9c.\">Member Manual</a>\n"
+"        If it's a mistake, or you think that you should be excused from this "
+"shift, please contact the member office: mitglied@supercoop.de .<br/>\n"
+"        As stated in the Member Manual, a missed shift must be compensated "
+"for by completing 2 make-up shifts within four weeks of your missed shift. "
+"You can schedule your make-up shifts directly on <a href=\"https://members."
+"supercoop.de/shifts/timetable\">Tapir</a>.<br/>\n"
+"        Please keep in mind that if you do not complete your make-up shifts "
+"your shopping and voting rights will be suspended. For more information "
+"please see the <a href=\"https://docs.google.com/document/"
+"d/19v91mj2MAJTtrPLCw54VMS6qlaiJqBqUAuiC6z_AKpw/edit#heading=h.lk042ux0tm9c."
+"\">Member Manual</a>\n"
 "        (Section III.F).\n"
 "    </p>\n"
 "\n"
@@ -1189,18 +1310,21 @@ msgstr ""
 "    <p>Dies ist eine automatische E-Mail von der SuperCoop.</p>\n"
 "\n"
 "    <p>\n"
-"       Es ist gerade im Tapir-System eingetragen worden, dass du an folgender Schicht "
-"nicht teilgenommen hast, obwohl du angemeldet warst :\n"
+"       Es ist gerade im Tapir-System eingetragen worden, dass du an "
+"folgender Schicht nicht teilgenommen hast, obwohl du angemeldet warst :\n"
 "        %(shift_display_name)s <br/>\n"
-"        Wenn dies ein Fehler ist, oder du für di Schicht entschuldigt sein solltest, "
-"kontaktiere bitte das Mitgliederbüro: mitglied@supercoop.de .<br/>\n"
-"        Im Mitgliederhandbuch steht: Wenn ein Mitglied eine Schicht versäumt, muss das "
-"Mitglied innerhalb von vier Wochen nach der versäumten Schicht an zwei Nachholschichten "
-"teilnehmen, um sie auszugleichen. Du kannst dich für die Nachholschichten selbst in <a "
-"href=\"https://members.supercoop.de/shifts/timetable\">Tapir</a> eintragen.<br/>\n"
-"        Wenn du deine Nachholschichten nicht machst, können deine Einkaufs- und Wahl-"
-"Rechte ausgesetzt werden. Für mehr Information siehe <a href=\"https://docs.google.com/"
-"document/d/12qqzJxgDIilSnVrh4yVJhqA_AJ6PLGpkw4JGDe3nBRg/edit#heading=h.594fbvgmke0z"
+"        Wenn dies ein Fehler ist, oder du für di Schicht entschuldigt sein "
+"solltest, kontaktiere bitte das Mitgliederbüro: mitglied@supercoop.de .<br/"
+">\n"
+"        Im Mitgliederhandbuch steht: Wenn ein Mitglied eine Schicht "
+"versäumt, muss das Mitglied innerhalb von vier Wochen nach der versäumten "
+"Schicht an zwei Nachholschichten teilnehmen, um sie auszugleichen. Du kannst "
+"dich für die Nachholschichten selbst in <a href=\"https://members.supercoop."
+"de/shifts/timetable\">Tapir</a> eintragen.<br/>\n"
+"        Wenn du deine Nachholschichten nicht machst, können deine Einkaufs- "
+"und Wahl-Rechte ausgesetzt werden. Für mehr Information siehe <a href="
+"\"https://docs.google.com/document/"
+"d/12qqzJxgDIilSnVrh4yVJhqA_AJ6PLGpkw4JGDe3nBRg/edit#heading=h.594fbvgmke0z"
 "\">Mitgliederhandbuch</a> III.F\n"
 "    </p>\n"
 "\n"
@@ -1234,10 +1358,12 @@ msgstr ""
 "    </p>\n"
 
 #: shifts/templates/shifts/email/shift_reminder.default.html:21
-msgid "In case you can't attend the shift, contact the team leader as soon as possible."
+msgid ""
+"In case you can't attend the shift, contact the team leader as soon as "
+"possible."
 msgstr ""
-"Wenn du an der Schicht nicht teilnehmen kannst, kontaktiere bitte schnellstmöglich die "
-"Teamleitung."
+"Wenn du an der Schicht nicht teilnehmen kannst, kontaktiere bitte "
+"schnellstmöglich die Teamleitung."
 
 #: shifts/templates/shifts/email/stand_in_found.html:7
 msgid "Stand-in found"
@@ -1252,13 +1378,13 @@ msgid ""
 "    <p>This is an automated email from %(coop_name)s.</p>\n"
 "\n"
 "    <p>\n"
-"        You were looking for a stand-in for the following shift: %(shift_display_name)s."
-"<br/>\n"
+"        You were looking for a stand-in for the following shift: "
+"%(shift_display_name)s.<br/>\n"
 "        Another member has taken over your slot for that shift.\n"
 "    </p>\n"
 "\n"
-"    <p>If you haven't done so already, don't forget to attend another shift to compensate "
-"for the one you will miss!</p>\n"
+"    <p>If you haven't done so already, don't forget to attend another shift "
+"to compensate for the one you will miss!</p>\n"
 msgstr ""
 "\n"
 "    <p>Hallo %(first_name)s,</p>\n"
@@ -1271,8 +1397,8 @@ msgstr ""
 "        Ein anderes Mitglied hat diese jetzt übernommen.\n"
 "    </p>\n"
 "\n"
-"    <p>Falls du es noch nicht gemacht hast, vergiss nicht an einer anderen Schicht "
-"teilzunehmen!</p>\n"
+"    <p>Falls du es noch nicht gemacht hast, vergiss nicht an einer anderen "
+"Schicht teilzunehmen!</p>\n"
 "\n"
 "    <p>Kooperative Grüße,</p>\n"
 
@@ -1300,36 +1426,93 @@ msgstr "Ändere den Schichtstatus zu"
 msgid "Update Shift User Data"
 msgstr "Nutzer*innendaten der Schicht aktualisieren"
 
+#: shifts/templates/shifts/members_on_alert_list.html:31
+msgid ""
+"\n"
+"                    The members in this list are on alert relative to their "
+"shift account : the current balance is -2\n"
+"                    or less.\n"
+"                "
+msgstr ""
+
+#: shifts/templates/shifts/register_user_to_shift_slot.html:15
+#, fuzzy
+#| msgid "Register for Shift"
+msgid "Register for shift slot"
+msgstr "Für eine Schicht anmelden"
+
+#: shifts/templates/shifts/register_user_to_shift_slot.html:28
+#: shifts/templates/shifts/shift_detail.html:39
+#, fuzzy
+#| msgid "Cancelled"
+msgid "Cancel"
+msgstr "Abgesagt"
+
+#: shifts/templates/shifts/register_user_to_shift_slot_template.html:15
+msgid "Register for ABCD Shift"
+msgstr "Für eine ABCD-Schicht anmelden"
+
+#: shifts/templates/shifts/register_user_to_shift_slot_template.html:33
+msgid "Some shifts are already occupied"
+msgstr "Manche Schichten sind bereits besetzt"
+
+#: shifts/templates/shifts/register_user_to_shift_slot_template.html:35
+msgid ""
+"\n"
+"                        <p>A flying member has already registered to the "
+"shifts linked below.</p>\n"
+"                        <p>It is still possible to sign someone up for this "
+"shift using the ABCD system. This would mean that the member is signing up "
+"to work this shift on a recurring 4 week basis (i.e. once per shift cycle).</"
+"p>\n"
+"                        <p>IMPORTANT: If a flying member had previously "
+"signed up for the same shift, the ABCD member will have to sign up for a "
+"different shift for that particular cycle.</p>\n"
+"                    "
+msgstr ""
+"\n"
+"<p>Ein fliegendes Mitglied hat sich bereits für die unten verlinkten "
+"Schichten angemeldet.</p><p>Es ist immer noch möglich, jemanden für diese "
+"Schicht über das ABCD-System anzumelden. Dies würde bedeuten, dass sich das "
+"Mitglied für diese Schicht auf einer wiederkehrenden 4-Wochen-Basis (d.h. "
+"einmal pro Schichtzyklus) anmeldet.</p><p>WICHTIG: Wenn sich ein fliegendes "
+"Mitglied zuvor für dieselbe Schicht angemeldet hat, muss sich das ABCD-"
+"Mitglied für eine andere Schicht für diesen bestimmten Zyklus anmelden.</p> "
+
+#: shifts/templates/shifts/register_user_to_shift_slot_template.html:40
+msgid "Already occupied shifts :"
+msgstr "Schon besetzte Schichten:"
+
 #: shifts/templates/shifts/shift_calendar_future.html:10
 #, python-format
 msgid ""
 "\n"
-"        <p>Below you can find all the upcoming shifts, and who is registered for each "
-"shift.</p>\n"
-"        <p>You can sign yourself up for any shift that has a free slot here on TAPIR. You "
-"may also cancel it yourself if done at least %(nb_days_for_self_unregister)s days before "
-"the shift.<br/>\n"
-"            When you sign up for one of these shifts, you only commit to the shift on that "
-"specific day.</p>\n"
-"        <p>To register for a regular ABCD shift you must contact the Member Office.</p>\n"
+"        <p>Below you can find all the upcoming shifts, and who is registered "
+"for each shift.</p>\n"
+"        <p>You can sign yourself up for any shift that has a free slot here "
+"on TAPIR. You may also cancel it yourself if done at least "
+"%(nb_days_for_self_unregister)s days before the shift.<br/>\n"
+"            When you sign up for one of these shifts, you only commit to the "
+"shift on that specific day.</p>\n"
+"        <p>To register for a regular ABCD shift you must contact the Member "
+"Office.</p>\n"
 "    "
 msgstr ""
 "\n"
-"<p>Unten findest du alle anstehenden Schichten und wer für die einzelnen Schichten "
-"angemeldet ist.</p></p> Du kannst dich für jede Schicht, die einen freien Platz hat, hier "
-"auf TAPIR anmelden. Du kannst dich auch selbst abmelden, wenn du dies mindestens "
-"%(nb_days_for_self_unregister)s Tage vor der Schicht tust. </p></p>Wenn du dich für eine "
-"dieser Schichten anmeldest, verpflichtest du dich nur für die Schicht an diesem bestimmten "
-"Tag.</p><p> Um dich für eine reguläre ABCD-Schicht anzumelden, musst du das Mitgliederbüro "
-"kontaktieren.</p> "
+"<p>Unten findest du alle anstehenden Schichten und wer für die einzelnen "
+"Schichten angemeldet ist.</p></p> Du kannst dich für jede Schicht, die einen "
+"freien Platz hat, hier auf TAPIR anmelden. Du kannst dich auch selbst "
+"abmelden, wenn du dies mindestens %(nb_days_for_self_unregister)s Tage vor "
+"der Schicht tust. </p></p>Wenn du dich für eine dieser Schichten anmeldest, "
+"verpflichtest du dich nur für die Schicht an diesem bestimmten Tag.</p><p> "
+"Um dich für eine reguläre ABCD-Schicht anzumelden, musst du das "
+"Mitgliederbüro kontaktieren.</p> "
 
 #: shifts/templates/shifts/shift_calendar_template.html:32
-#: shifts/templates/shifts/shift_template_group_calendar.html:16
 msgid "starting"
 msgstr "beginnt"
 
 #: shifts/templates/shifts/shift_calendar_template.html:33
-#: shifts/templates/shifts/shift_template_group_calendar.html:16
 #: shifts/templates/shifts/shift_template_overview.html:38
 msgid "Week "
 msgstr "Woche "
@@ -1343,11 +1526,6 @@ msgstr "Platz"
 #: shifts/templates/shifts/shift_detail_printable.html:47
 msgid "Member"
 msgstr "Mitglied"
-
-#: shifts/templates/shifts/shift_day_printable.html:66
-#: shifts/templates/shifts/shift_template_detail.html:44
-msgid "optional"
-msgstr "optional"
 
 #: shifts/templates/shifts/shift_day_printable.html:69
 #: shifts/templates/shifts/shift_detail_printable.html:61
@@ -1363,59 +1541,65 @@ msgstr "Hat Befähigungen: "
 msgid "Get printable version"
 msgstr "Druckversion erhalten"
 
-#: shifts/templates/shifts/shift_detail.html:41
+#: shifts/templates/shifts/shift_detail.html:46
 msgid "Generated from"
 msgstr "Erzeugt von"
 
-#: shifts/templates/shifts/shift_detail.html:54
+#: shifts/templates/shifts/shift_detail.html:60
+msgid "This shift has been cancelled: "
+msgstr ""
+
+#: shifts/templates/shifts/shift_detail.html:65
 msgid "List of slots for this shift"
 msgstr "Liste der Slots für diese Schicht"
 
-#: shifts/templates/shifts/shift_detail.html:58
+#: shifts/templates/shifts/shift_detail.html:69
 #: shifts/templates/shifts/shift_template_detail.html:32
 msgid "Details"
 msgstr "Details"
 
-#: shifts/templates/shifts/shift_detail.html:59
+#: shifts/templates/shifts/shift_detail.html:70
 #: shifts/templates/shifts/shift_template_detail.html:33
 msgid "Registered user"
 msgstr "Angemeldete*r Nutzer*in"
 
-#: shifts/templates/shifts/shift_detail.html:60
+#: shifts/templates/shifts/shift_detail.html:71
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: shifts/templates/shifts/shift_detail.html:61
+#: shifts/templates/shifts/shift_detail.html:72
 msgid "Actions"
 msgstr "Aktionen"
 
-#: shifts/templates/shifts/shift_detail.html:63
+#: shifts/templates/shifts/shift_detail.html:74
 msgid "Member-Office actions"
 msgstr "Mitgliederbüro Aktionen"
 
-#: shifts/templates/shifts/shift_detail.html:64
+#: shifts/templates/shifts/shift_detail.html:75
 msgid "Previous attendances"
 msgstr "Vorherige Anwesenheiten"
 
-#: shifts/templates/shifts/shift_detail.html:86
+#: shifts/templates/shifts/shift_detail.html:97
 msgid "since"
 msgstr "seit"
 
-#: shifts/templates/shifts/shift_detail.html:90
+#: shifts/templates/shifts/shift_detail.html:101
 msgid "Vacant"
 msgstr "Frei"
 
-#: shifts/templates/shifts/shift_detail.html:102
-msgid "Cancels the search for a stand-in. Use this if you want to attend the shift."
+#: shifts/templates/shifts/shift_detail.html:113
+msgid ""
+"Cancels the search for a stand-in. Use this if you want to attend the shift."
 msgstr ""
-"Beendet die Suche nach Vertretung. Benutze dies, wenn du die Schicht wahrnehmen möchtest."
+"Beendet die Suche nach Vertretung. Benutze dies, wenn du die Schicht "
+"wahrnehmen möchtest."
 
-#: shifts/templates/shifts/shift_detail.html:104
-#: shifts/templates/shifts/shift_detail.html:226
+#: shifts/templates/shifts/shift_detail.html:115
+#: shifts/templates/shifts/shift_detail.html:221
 msgid "Cancel looking for a stand-in"
 msgstr "Beende die Suche nach Vertretung"
 
-#: shifts/templates/shifts/shift_detail.html:112
+#: shifts/templates/shifts/shift_detail.html:123
 #, python-format
 msgid ""
 "You can only look for a\n"
@@ -1423,68 +1607,78 @@ msgid ""
 "                                                    %(NB_DAYS_FOR_SELF_LOOK_FOR_STAND_IN)s "
 "days before the shift. If\n"
 "                                                    you can't\n"
-"                                                    attend, contact your shift leader as "
-"soon as\n"
+"                                                    attend, contact your "
+"shift leader as soon as\n"
 "                                                    possible."
 msgstr ""
-"Du kannst nur bis %(NB_DAYS_FOR_SELF_LOOK_FOR_STAND_IN)s Tage vor der Schicht nach einer "
-"Vertretung suchen. Wenn du die Schicht nicht wahrnehmen kannst, wende dich bitte "
-"schnellstmöglich an die Teamleitung."
+"Du kannst nur bis %(NB_DAYS_FOR_SELF_LOOK_FOR_STAND_IN)s Tage vor der "
+"Schicht nach einer Vertretung suchen. Wenn du die Schicht nicht wahrnehmen "
+"kannst, wende dich bitte schnellstmöglich an die Teamleitung."
 
-#: shifts/templates/shifts/shift_detail.html:125
+#: shifts/templates/shifts/shift_detail.html:135
 msgid "Look for a stand-in"
 msgstr "Suche nach Vertretung"
 
-#: shifts/templates/shifts/shift_detail.html:135
+#: shifts/templates/shifts/shift_detail.html:145
 #, python-format
 msgid ""
 "You can only unregister\n"
 "                                                yourself\n"
-"                                                %(NB_DAYS_FOR_SELF_UNREGISTER)s days "
-"before the shift. Also,\n"
+"                                                %(NB_DAYS_FOR_SELF_UNREGISTER)s "
+"days before the shift. Also,\n"
 "                                                ABCD-Shifts\n"
-"                                                can't be unregistered from. If you can't\n"
-"                                                attend, look for a stand-in or contact "
-"your shift leader as soon as\n"
+"                                                can't be unregistered from. "
+"If you can't\n"
+"                                                attend, look for a stand-in "
+"or contact your shift leader as soon as\n"
 "                                                possible."
 msgstr ""
-"Du kannst dich nur bis %(NB_DAYS_FOR_SELF_UNREGISTER)s Tage vor deiner Schicht abmelden. "
-"Von ABCD-Schichten kannst du dich überhaupt nicht abmelden. Wenn du die Schicht nicht "
-"wahrnehmen kannst, suche bitte eine Vertretung oder melde dich schnellstmöglich bei deiner "
-"Teamleitung."
+"Du kannst dich nur bis %(NB_DAYS_FOR_SELF_UNREGISTER)s Tage vor deiner "
+"Schicht abmelden. Von ABCD-Schichten kannst du dich überhaupt nicht "
+"abmelden. Wenn du die Schicht nicht wahrnehmen kannst, suche bitte eine "
+"Vertretung oder melde dich schnellstmöglich bei deiner Teamleitung."
 
-#: shifts/templates/shifts/shift_detail.html:149
+#: shifts/templates/shifts/shift_detail.html:159
 msgid "Unregister myself"
 msgstr "Melde mich ab"
 
-#: shifts/templates/shifts/shift_detail.html:158
+#: shifts/templates/shifts/shift_detail.html:164
+#, fuzzy
+#| msgid ""
+#| "You can only register\n"
+#| "                                                yourself\n"
+#| "                                                for a shift if:<br/>\n"
+#| "                                                -You are not registered "
+#| "to another slot in that shift<br/>\n"
+#| "                                                -You have the required "
+#| "qualification (if you want to get a\n"
+#| "                                                qualification, contact "
+#| "the member office)<br/>\n"
+#| "                                                -The shift is in the "
+#| "future<br/>\n"
+#| "                                            "
 msgid ""
 "You can only register\n"
-"                                                yourself\n"
-"                                                for a shift if:<br/>\n"
-"                                                -You are not registered to another slot in "
-"that shift<br/>\n"
-"                                                -You have the required qualification (if "
-"you want to get a\n"
-"                                                qualification, contact the member "
-"office)<br/>\n"
-"                                                -The shift is in the future<br/>\n"
-"                                            "
+"                                            yourself\n"
+"                                            for a shift if:<br/>\n"
+"                                            -You are not registered to "
+"another slot in that shift<br/>\n"
+"                                            -You have the required "
+"qualification (if you want to get a\n"
+"                                            qualification, contact the "
+"member office)<br/>\n"
+"                                            -The shift is in the future<br/"
+">\n"
+"                                            -The shift is not cancelled "
+"(holidays...)<br/>\n"
+"                                        "
 msgstr ""
 "Du kannst dich nur für eine Schicht anmelden, wenn\n"
 "- du keinen anderen Platz in derselben Schicht gebucht hast\n"
-"- du das erforderliche Training gemacht hast (wenn du ein Training möchtest, wende dich "
-"bitte ans Mitgliederbüro\n"
+"- du das erforderliche Training gemacht hast (wenn du ein Training möchtest, "
+"wende dich bitte ans Mitgliederbüro\n"
 "- die Schicht in der Zukunft liegt\n"
 " "
-
-#: shifts/templates/shifts/shift_detail.html:173
-msgid "Register myself"
-msgstr "Melde mich an"
-
-#: shifts/templates/shifts/shift_detail.html:191
-msgid "Register a member"
-msgstr "Melde ein Mitglied an"
 
 #: shifts/templates/shifts/shift_filters.html:4
 msgid "Filters"
@@ -1515,15 +1709,22 @@ msgctxt "Filters"
 msgid "Other shifts"
 msgstr "Andere Schichten"
 
-#: shifts/templates/shifts/shift_filters.html:49
+#: shifts/templates/shifts/shift_filters.html:47
+#, fuzzy
+#| msgid "Cancelled"
+msgctxt "Filters"
+msgid "Cancelled"
+msgstr "Abgesagt"
+
+#: shifts/templates/shifts/shift_filters.html:51
 msgid "Free slot"
 msgstr "Hat einen freien Platz"
 
-#: shifts/templates/shifts/shift_filters.html:51
+#: shifts/templates/shifts/shift_filters.html:53
 msgid "ABCD attendance"
 msgstr "ABCD Anwesenheit"
 
-#: shifts/templates/shifts/shift_filters.html:53
+#: shifts/templates/shifts/shift_filters.html:55
 msgid "Flying attendance"
 msgstr "Fliegende Anwesenheit"
 
@@ -1531,16 +1732,16 @@ msgstr "Fliegende Anwesenheit"
 msgid "List of slots for this ABCD shifts"
 msgstr "Liste des Slots für diese ABCD-Schicht"
 
-#: shifts/templates/shifts/shift_template_detail.html:64
+#: shifts/templates/shifts/shift_template_detail.html:61
 #: shifts/templates/shifts/user_shifts_overview_tag.html:52
 msgid "Unregister"
 msgstr "Abmelden"
 
-#: shifts/templates/shifts/shift_template_detail.html:93
+#: shifts/templates/shifts/shift_template_detail.html:84
 msgid "Future generated Shifts"
 msgstr "Zukünftige erstellte Schichten"
 
-#: shifts/templates/shifts/shift_template_detail.html:107
+#: shifts/templates/shifts/shift_template_detail.html:98
 msgid "Past generated Shifts"
 msgstr "Vergangene Schichten"
 
@@ -1559,23 +1760,23 @@ msgstr "ABCD-Zeitplan Übersicht, laufende Woche: "
 #: shifts/templates/shifts/shift_template_overview.html:22
 msgid ""
 "\n"
-"                    <p>This is the ABCD shiftplan. It repeats every four weeks. That's why "
-"you see only weekdays\n"
-"                        (Monday, Tuesday...) and the week (A,B,C or D), instead of "
-"specific dates (e.g. 23.8.2021).\n"
-"                        To see the date of your next shift, please go to your profile.</"
-"p>\n"
-"                    <p>If you would like to change your regular ABCD shift, please contact "
-"the Member Office.</p>\n"
+"                    <p>This is the ABCD shiftplan. It repeats every four "
+"weeks. That's why you see only weekdays\n"
+"                        (Monday, Tuesday...) and the week (A,B,C or D), "
+"instead of specific dates (e.g. 23.8.2021).\n"
+"                        To see the date of your next shift, please go to "
+"your profile.</p>\n"
+"                    <p>If you would like to change your regular ABCD shift, "
+"please contact the Member Office.</p>\n"
 "                "
 msgstr ""
 "\n"
-"<p>Dies ist der ABCD-Zeitplan. Er wiederholt sich alle vier Wochen. Deswegen siehst du nur "
-"Wochentage (Montag, Dienstag...) und die Woche (A,B,C oder D) anstatt genauer "
-"Datumsangaben (z.B. 23.8.2021). Um das Datum deiner nächsten Schicht zu sehen, geh bitte "
-"zu deinem Kontoprofil. </p>\n"
-"<p>Wenn du deine regelmäßige ABCD-Schicht ändern möchtest, wende dich bitte ans "
-"Mitgliederbüro.</p>\n"
+"<p>Dies ist der ABCD-Zeitplan. Er wiederholt sich alle vier Wochen. Deswegen "
+"siehst du nur Wochentage (Montag, Dienstag...) und die Woche (A,B,C oder D) "
+"anstatt genauer Datumsangaben (z.B. 23.8.2021). Um das Datum deiner nächsten "
+"Schicht zu sehen, geh bitte zu deinem Kontoprofil. </p>\n"
+"<p>Wenn du deine regelmäßige ABCD-Schicht ändern möchtest, wende dich bitte "
+"ans Mitgliederbüro.</p>\n"
 " "
 
 #: shifts/templates/shifts/shift_template_overview.html:33
@@ -1622,55 +1823,27 @@ msgstr "Inaktiv"
 msgid "Edit user shift data"
 msgstr "Bearbeite Nutzer*in-Schichtdaten"
 
-#: shifts/templates/shifts/slot_register.html:16
-msgid "Shift"
-msgstr "Schicht"
-
-#: shifts/templates/shifts/slot_register.html:29
-msgid "Register for Shift"
-msgstr "Für eine Schicht anmelden"
-
-#: shifts/templates/shifts/slot_template_register.html:16
-#: shifts/templates/shifts/user_shifts_overview_tag.html:34
-msgid "ABCD Shift"
-msgstr "ABCD-Schicht"
-
-#: shifts/templates/shifts/slot_template_register.html:29
-msgid "Register for ABCD Shift"
-msgstr "Für eine ABCD-Schicht anmelden"
-
-#: shifts/templates/shifts/slot_template_register.html:47
-msgid "Some shifts are already occupied"
-msgstr "Manche Schichten sind bereits besetzt"
-
-#: shifts/templates/shifts/slot_template_register.html:49
-msgid ""
-"\n"
-"                        <p>A flying member has already registered to the shifts linked "
-"below.</p>\n"
-"                        <p>It is still possible to sign someone up for this shift using "
-"the ABCD system. This would mean that the member is signing up to work this shift on a "
-"recurring 4 week basis (i.e. once per shift cycle).</p>\n"
-"                        <p>IMPORTANT: If a flying member had previously signed up for the "
-"same shift, the ABCD member will have to sign up for a different shift for that particular "
-"cycle.</p>\n"
-"                    "
-msgstr ""
-"\n"
-"<p>Ein fliegendes Mitglied hat sich bereits für die unten verlinkten Schichten angemeldet."
-"</p><p>Es ist immer noch möglich, jemanden für diese Schicht über das ABCD-System "
-"anzumelden. Dies würde bedeuten, dass sich das Mitglied für diese Schicht auf einer "
-"wiederkehrenden 4-Wochen-Basis (d.h. einmal pro Schichtzyklus) anmeldet.</p><p>WICHTIG: "
-"Wenn sich ein fliegendes Mitglied zuvor für dieselbe Schicht angemeldet hat, muss sich das "
-"ABCD-Mitglied für eine andere Schicht für diesen bestimmten Zyklus anmelden.</p> "
-
-#: shifts/templates/shifts/slot_template_register.html:54
-msgid "Already occupied shifts :"
-msgstr "Schon besetzte Schichten:"
-
-#: shifts/templates/shifts/statistics.html:11
+#: shifts/templates/shifts/statistics.html:35
 msgid "Statistics on shifts"
 msgstr "Shicht-Statistiken"
+
+#: shifts/templates/shifts/statistics.html:44
+msgid "Gives details of the attendance per slot type."
+msgstr ""
+
+#: shifts/templates/shifts/statistics.html:63
+msgid "Gives details of the attendance for the past, current and next week."
+msgstr ""
+
+#: shifts/templates/shifts/statistics.html:85
+#, fuzzy
+#| msgid "Shift system"
+msgid "Shift cycle list"
+msgstr "Schichten"
+
+#: shifts/templates/shifts/statistics.html:88
+msgid "Gives details of the attendance per shift cycle."
+msgstr ""
 
 #: shifts/templates/shifts/user_shift_account_log.html:10
 msgid "Shift account log for: "
@@ -1695,6 +1868,10 @@ msgstr "Wert"
 #: shifts/templates/shifts/user_shifts_overview_tag.html:26
 msgid "Set ABCD 🏠️"
 msgstr "Als ABCD markieren 🏠️"
+
+#: shifts/templates/shifts/user_shifts_overview_tag.html:34
+msgid "ABCD Shift"
+msgstr "ABCD-Schicht"
 
 #: shifts/templates/shifts/user_shifts_overview_tag.html:66
 msgid "Find an ABCD shift"
@@ -1763,26 +1940,28 @@ msgstr "Keine"
 msgid "View all"
 msgstr "Alle ansehen"
 
-#: shifts/templatetags/shifts.py:46 shifts/templatetags/shifts.py:118 shifts/views.py:535
+#: shifts/templatetags/shifts.py:55 shifts/templatetags/shifts.py:127
+#: shifts/views/views.py:88
 msgid "General"
 msgstr "Allgemein"
 
-#: shifts/views.py:337
+#: shifts/views/attendance.py:174
 msgid "You missed your shift!"
 msgstr "Du hast deine Schicht versäumt!"
 
-#: shifts/views.py:731
+#: shifts/views/exemptions.py:45
 msgid "Is covered by shift exemption: "
 msgstr "Ist abgedeckt durch Schicht Befreiung : "
 
 #: utils/forms.py:23
 msgid ""
-"German phone number don't need a prefix (e.g. (0)1736160646), international always (e.g. "
-"+12125552368)"
+"German phone number don't need a prefix (e.g. (0)1736160646), international "
+"always (e.g. +12125552368)"
 msgstr ""
-"Innerstädtische und Mobilfunk-Verbindungen benötigen keine Vorwahlnummer (z.B. "
-"01736160646), internationale Verbindungen benötigen die Landesvorwahlnummer für Mobilfunk, "
-"für Festnetz die Landes- und Ortsvorwahlnummer"
+"Innerstädtische und Mobilfunk-Verbindungen benötigen keine Vorwahlnummer (z."
+"B. 01736160646), internationale Verbindungen benötigen die "
+"Landesvorwahlnummer für Mobilfunk, für Festnetz die Landes- und "
+"Ortsvorwahlnummer"
 
 #: utils/models.py:13
 msgid "Andorra"
@@ -2756,12 +2935,45 @@ msgstr "Anfangsdatum muss gesetzt sein"
 msgid "Start date must be prior to end date"
 msgstr "Anfangsdatum muss vor Endsdatum sein"
 
+#~ msgid "Monday"
+#~ msgstr "Montag"
+
+#~ msgid "Tuesday"
+#~ msgstr "Dienstag"
+
+#~ msgid "Wednesday"
+#~ msgstr "Mittwoch"
+
+#~ msgid "Thursday"
+#~ msgstr "Donnerstag"
+
+#~ msgid "Friday"
+#~ msgstr "Freitag"
+
+#~ msgid "Saturday"
+#~ msgstr "Samstag"
+
+#~ msgid "Sunday"
+#~ msgstr "Sonntag"
+
+#~ msgid "optional"
+#~ msgstr "optional"
+
+#~ msgid "Register myself"
+#~ msgstr "Melde mich an"
+
+#~ msgid "Register a member"
+#~ msgstr "Melde ein Mitglied an"
+
+#~ msgid "Shift"
+#~ msgstr "Schicht"
+
 #~ msgid ""
-#~ "Since this is your first shift, remember to arrive 20 minutes before the beginning of "
-#~ "the shift in order to get the instructions you need."
+#~ "Since this is your first shift, remember to arrive 20 minutes before the "
+#~ "beginning of the shift in order to get the instructions you need."
 #~ msgstr ""
-#~ "Weil es deine erste Schicht ist, komm bitte 20 Minuten vor der Schicht an um die "
-#~ "Erklärungen zu bekommen."
+#~ "Weil es deine erste Schicht ist, komm bitte 20 Minuten vor der Schicht an "
+#~ "um die Erklärungen zu bekommen."
 
 #~ msgid "Welcome at SuperCoop eG!"
 #~ msgstr "Willkommen in der SuperCoop eG!"


### PR DESCRIPTION
-Three small things:
- Updated black in `.pre-commit` since v22 was having problems with `click` package (that commit was not intended within this PR but cherry-picking felt like overkill for such small change)
- translation for the annual calendar in the sidebar fixed by using `.format()`
- renamed weekly calendar to annual since it's one and makes it more distinguishable from "ABCD-shifts week-plan" entry. The black formatting created a lot of diffs in django.po though. The relevant changes are 905-906/985