### PR TITLE
Improve draftuser and shareowner list

### DIFF
--- a/tapir/coop/templates/coop/draftuser_list.html
+++ b/tapir/coop/templates/coop/draftuser_list.html
@@ -15,13 +15,14 @@
         </h5>
         <div class="card-body">
 
-            <table class="table table-striped" id="applicants_table" aria-label="{% translate 'List of applicants' %}">
+            <table class="table table-striped table-responsive" id="applicants_table" aria-label="{% translate 'List of applicants' %}">
                 <thead>
                 <th>{% translate "First name" %}</th>
                 <th>{% translate "Last name" %}</th>
                 <th>{% translate "Email" %}</th>
                 <th>{% translate "Beteiligungserklärung" %}</th>
                 <th>{% translate "Entrance Fee" %}</th>
+                <th>{% translate "Date" %}</th>
                 <th></th>
                 </thead>
                 {% for u in object_list %}
@@ -39,6 +40,7 @@
                                 <span class="text-success">{% translate "Paid" %}</span>
                             {% endif %}
                         </td>
+                        <td class="align-middle">{{ u.created_at|date:"d.m.Y" }}</td>
                         <td class="align-middle">
                             <a class="btn tapir-btn btn-outline-primary" href="{% url "coop:draftuser_detail" u.pk %}">
                                 <span class="material-icons">visibility</span>

--- a/tapir/coop/templates/coop/draftuser_list.html
+++ b/tapir/coop/templates/coop/draftuser_list.html
@@ -14,42 +14,45 @@
             </span>
         </h5>
         <div class="card-body">
-
-            <table class="table table-striped table-responsive" id="applicants_table" aria-label="{% translate 'List of applicants' %}">
-                <thead>
-                <th>{% translate "First name" %}</th>
-                <th>{% translate "Last name" %}</th>
-                <th>{% translate "Email" %}</th>
-                <th>{% translate "Beteiligungserklärung" %}</th>
-                <th>{% translate "Entrance Fee" %}</th>
-                <th>{% translate "Date" %}</th>
-                <th></th>
-                </thead>
-                {% for u in object_list %}
-                    <tr>
-                        <td class="align-middle">{{ u.first_name }}</td>
-                        <td class="align-middle">{{ u.last_name }}</td>
-                        <td class="align-middle">{{ u.email }}</td>
-                        <td class="align-middle">
-                            {% if u.signed_membership_agreement %}
-                                <span class="text-success">{% translate "Signed" %}</span>
-                            {% endif %}
-                        </td>
-                        <td class="align-middle">
-                            {% if u.paid_membership_fee %}
-                                <span class="text-success">{% translate "Paid" %}</span>
-                            {% endif %}
-                        </td>
-                        <td class="align-middle">{{ u.created_at|date:"d.m.Y" }}</td>
-                        <td class="align-middle">
-                            <a class="btn tapir-btn btn-outline-primary" href="{% url "coop:draftuser_detail" u.pk %}">
-                                <span class="material-icons">visibility</span>
-                                Show
-                            </a>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </table>
+            <div class="table-responsive">
+                <table class="table table-striped" id="applicants_table"
+                       aria-label="{% translate 'List of applicants' %}">
+                    <thead>
+                    <th>{% translate "First name" %}</th>
+                    <th>{% translate "Last name" %}</th>
+                    <th>{% translate "Email" %}</th>
+                    <th>{% translate "Beteiligungserklärung" %}</th>
+                    <th>{% translate "Entrance Fee" %}</th>
+                    <th>{% translate "Date" %}</th>
+                    <th></th>
+                    </thead>
+                    {% for u in object_list %}
+                        <tr>
+                            <td class="align-middle">{{ u.first_name }}</td>
+                            <td class="align-middle">{{ u.last_name }}</td>
+                            <td class="align-middle">{{ u.email }}</td>
+                            <td class="align-middle">
+                                {% if u.signed_membership_agreement %}
+                                    <span class="text-success">{% translate "Signed" %}</span>
+                                {% endif %}
+                            </td>
+                            <td class="align-middle">
+                                {% if u.paid_membership_fee %}
+                                    <span class="text-success">{% translate "Paid" %}</span>
+                                {% endif %}
+                            </td>
+                            <td class="align-middle">{{ u.created_at|date:"d.m.Y" }}</td>
+                            <td class="align-middle">
+                                <a class="btn tapir-btn btn-outline-primary"
+                                   href="{% url "coop:draftuser_detail" u.pk %}">
+                                    <span class="material-icons">visibility</span>
+                                    Show
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/tapir/coop/templates/coop/shareowner_list.html
+++ b/tapir/coop/templates/coop/shareowner_list.html
@@ -50,7 +50,9 @@
                     </div>
                 </form>
             {% endif %}
+            <div class="table-responsive">
             {% render_table table %}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/tapir/coop/views/draftuser.py
+++ b/tapir/coop/views/draftuser.py
@@ -27,6 +27,7 @@ from tapir.utils.models import copy_user_info
 class DraftUserViewMixin:
     model = DraftUser
     form_class = DraftUserForm
+    ordering = ["created_at"]
 
 
 class DraftUserListView(PermissionRequiredMixin, DraftUserViewMixin, generic.ListView):


### PR DESCRIPTION
A minor change but makes `DraftUser` and `ShareOwner` lists responsive and the `DraftUser` list a lot more usable (sorted by `created_at` and shows creation date in the list)