### PR TITLE
shift date now shown at edit

### DIFF
--- a/tapir/shifts/forms.py
+++ b/tapir/shifts/forms.py
@@ -32,8 +32,12 @@ class ShiftCreateForm(forms.ModelForm):
             "description",
         ]
         widgets = {
-            "start_time": forms.widgets.DateTimeInput(attrs={"type": "datetime-local"}),
-            "end_time": forms.widgets.DateTimeInput(attrs={"type": "datetime-local"}),
+            "start_time": forms.widgets.DateTimeInput(
+                attrs={"type": "datetime-local"}, format="%Y-%m-%dT%H:%M"
+            ),
+            "end_time": forms.widgets.DateTimeInput(
+                attrs={"type": "datetime-local"}, format="%Y-%m-%dT%H:%M"
+            ),
         }
 
     def clean_end_time(self):
@@ -197,7 +201,9 @@ class CreateShiftAccountEntryForm(forms.ModelForm):
         model = ShiftAccountEntry
         fields = ["date", "value", "description"]
         widgets = {
-            "date": forms.widgets.DateTimeInput(attrs={"type": "datetime-local"})
+            "date": forms.widgets.DateTimeInput(
+                attrs={"type": "datetime-local"}, format="%Y-%m-%dT%H:%M"
+            ),
         }
 
 


### PR DESCRIPTION
Just a small one to fix #247. It's basically overwriting the settings, which should contain date format. Hence, this issue might be related #115 but not sure