### PR TITLE
"Hotfix": user sees only appropriate list of actors

### DIFF
--- a/tapir/log/views.py
+++ b/tapir/log/views.py
@@ -110,13 +110,18 @@ class LogFilter(django_filters.FilterSet):
         if self.request.user.has_perm("coop.view"):
             # In case the user who requests the Logs actually has permission, make a list of all ShareOwners
             share_owner_list = ShareOwner.objects.order_by("id")
+            user_list = TapirUser.objects.all()
         else:
             share_owner_list = ShareOwner.objects.filter(
                 id=self.request.user.share_owner.id
             )
+            user_list = TapirUser.objects.filter(pk=self.request.user.pk)
+
         self.filters["members"].field.queryset = share_owner_list
         self.filters["actor"].field.queryset = TapirUser.objects.filter(
-            id__in=LogEntry.objects.all().values_list("actor", flat=True).distinct()
+            id__in=LogEntry.objects.filter(user_id__in=user_list)
+            .values_list("actor", flat=True)
+            .distinct()
         )
 
     time = DateRangeFilter(field_name="created_date")


### PR DESCRIPTION
I noticed that a normal member can see all the actor available in the Log-Details. That was because I thought LogEntries are only available for specific users, but `LogEntry.object.all()` exposes (of course) all LogEntries of all users, despite rights of a user.

This fixes this problem using has_perm. Even cooler would a pre-filtered list of actors only for the selected member maybe