### PR TITLE
#367: Cache user permissions in LdapUser to avoid querying ldap multiple times.

### DIFF
--- a/tapir/accounts/models.py
+++ b/tapir/accounts/models.py
@@ -76,15 +76,23 @@ class LdapUser(AbstractUser):
         return self.get_ldap().check_password(raw_password)
 
     def has_perm(self, perm, obj=None):
+        if not hasattr(self, "__cached_perms"):
+            self.__cached_perms = {}
+
+        if perm in self.__cached_perms.keys():
+            return self.__cached_perms[perm]
+
         user_dn = self.get_ldap().build_dn()
         for group_cn in settings.PERMISSIONS.get(perm, []):
             group = LdapGroup.objects.filter(cn=group_cn).first()
             if not group:
                 continue
             if user_dn in group.members:
+                self.__cached_perms[perm] = True
                 return True
 
-        return super().has_perm(perm=perm, obj=obj)
+        self.__cached_perms[perm] = super().has_perm(perm=perm, obj=obj)
+        return self.__cached_perms[perm]
 
 
 class TapirUserQuerySet(models.QuerySet):


### PR DESCRIPTION
Hey everyone,
The change is quite straightforward but since it's touching permissions I wanted everyone's advice.

I get ~50ms less per request on my local windows machine with Silk profiling enabled, so probably we only win a few ms on the live server, but well.