### PR TITLE
remove password from instance dictionary

### DIFF
--- a/tapir/accounts/models.py
+++ b/tapir/accounts/models.py
@@ -139,6 +139,7 @@ class TapirUser(LdapUser):
     city = models.CharField(_("City"), max_length=50, blank=True)
     country = CountryField(_("Country"), blank=True, default="DE")
     co_purchaser = models.CharField(_("Co-Purchaser"), max_length=150, blank=True)
+    excluded_fields = ["password"]
 
     preferred_language = models.CharField(
         _("Preferred Language"),

--- a/tapir/accounts/views.py
+++ b/tapir/accounts/views.py
@@ -45,8 +45,12 @@ class TapirUserUpdateView(
         with transaction.atomic():
             response = super().form_valid(form)
 
+            # remove password
             new_frozen = freeze_for_log(form.instance)
-            if self.old_object_frozen != new_frozen:
+            new_frozen.pop("password")
+            old_frozen = self.old_object_frozen
+            old_frozen.pop("password")
+            if old_frozen != new_frozen:
                 UpdateTapirUserLogEntry().populate(
                     old_frozen=self.old_object_frozen,
                     new_frozen=new_frozen,

--- a/tapir/accounts/views.py
+++ b/tapir/accounts/views.py
@@ -45,12 +45,8 @@ class TapirUserUpdateView(
         with transaction.atomic():
             response = super().form_valid(form)
 
-            # remove password
             new_frozen = freeze_for_log(form.instance)
-            new_frozen.pop("password")
-            old_frozen = self.old_object_frozen
-            old_frozen.pop("password")
-            if old_frozen != new_frozen:
+            if self.old_object_frozen != new_frozen:
                 UpdateTapirUserLogEntry().populate(
                     old_frozen=self.old_object_frozen,
                     new_frozen=new_frozen,

--- a/tapir/log/util.py
+++ b/tapir/log/util.py
@@ -9,4 +9,7 @@ def freeze_for_log(instance) -> dict:
         data[f.name] = f.value_from_object(instance)
     for f in opts.many_to_many:
         data[f.name] = [i.id for i in f.value_from_object(instance)]
+    if hasattr(instance, "excluded_fields"):
+        for field in instance.excluded_fields:
+            del data[field]
     return data


### PR DESCRIPTION
Resolves #357:
Problem was that, even without change, freeze_for_log(form.instance) also had `'password': '!LqXyPutnkQmtWqTIHPUb2GuPLuO3zdgMjgpuQUYF'` in it, which was not the case for old_freeze.

I bet there are nicer ways, like excluding fields before already, but no Logs are created when nothing has changed