### PR TITLE
Exclude python-ldap for windows users

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 /venv
+/.venv
 /.pytest_cache
 /.idea
 /.github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black

--- a/poetry.lock
+++ b/poetry.lock
@@ -1625,7 +1625,7 @@ test = ["pytest"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "16d261b45ea41bc960719df1b8dd3754a55b4a161d0530a78d49849f789c3537"
+content-hash = "a2263d068f52d4e751399738b75f3e567fb6a24892f322fc24e538aee6de147b"
 
 [metadata.files]
 amqp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Leon Handreke <leonh@ndreke.de>"]
 [tool.poetry.dependencies]
 python = "^3.10"
 Django = "~3.2.16"
-django-ldapdb = {version="^1.5.1", markers="sys_platform=='linux'"}
+django-ldapdb = {version="^1.5.1", markers="sys_platform=='linux' or sys_platform=='darwin'"}
 django-weasyprint = "^2.2.0"
 django-extensions = "^3.2.1"
 django-bootstrap-datepicker-plus = "^4.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Leon Handreke <leonh@ndreke.de>"]
 [tool.poetry.dependencies]
 python = "^3.10"
 Django = "~3.2.16"
-django-ldapdb = "^1.5.1"
+django-ldapdb = {version="^1.5.1", markers="sys_platform=='linux'"}
 django-weasyprint = "^2.2.0"
 django-extensions = "^3.2.1"
 django-bootstrap-datepicker-plus = "^4.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,5 +46,5 @@ factory-boy = "^3.2.1"
 poetryup = "^0.12.3"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ ipython = "^8.5.0"
 django-chartjs = "^2.3.0"
 unidecode = "^1.3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "^22.10.0"
 ipython = "^8.5.0"
 pre-commit = "^2.20.0"


### PR DESCRIPTION
I tested it on both Linux and windows and it seems to work for both local and Docker installation. It seems that I had to had .\venv to .dockerignore, since it otherwise got copied.
Did also few other things