### PR TITLE
#55 admins must be able to create and edit shift templates

### DIFF
--- a/tapir/shifts/apps.py
+++ b/tapir/shifts/apps.py
@@ -81,10 +81,18 @@ class ShiftConfig(AppConfig):
         )
 
         shifts_group.add_link(
+            display_name=_("Add an ABCD shift"),
+            material_icon="add_circle_outline",
+            url=reverse_lazy("shifts:shift_template_create"),
+            required_permissions=[PERMISSION_SHIFTS_MANAGE],
+            ordering=8,
+        )
+
+        shifts_group.add_link(
             display_name=_("Shift statistics"),
             material_icon="calculate",
             url=reverse_lazy("shifts:statistics"),
-            ordering=8,
+            ordering=9,
         )
 
     @classmethod

--- a/tapir/shifts/forms.py
+++ b/tapir/shifts/forms.py
@@ -374,7 +374,7 @@ class ShiftSlotTemplateForm(forms.ModelForm):
 
     check_update_future_shifts = BooleanField(
         label=_(
-            "I understand that adding a slot to this ABCD shift will add the slot to all the corresponding future shifts"
+            "I understand that adding or editing a slot to this ABCD shift will affect all the corresponding future shifts"
         ),
         required=True,
     )

--- a/tapir/shifts/forms.py
+++ b/tapir/shifts/forms.py
@@ -357,3 +357,24 @@ class ShiftTemplateForm(forms.ModelForm):
         ),
         required=True,
     )
+
+
+class ShiftSlotTemplateForm(forms.ModelForm):
+    class Meta:
+        model = ShiftSlotTemplate
+        fields = ["name", "required_capabilities", "warnings"]
+        widgets = {
+            "required_capabilities": forms.widgets.CheckboxSelectMultiple(
+                choices=SHIFT_USER_CAPABILITY_CHOICES.items()
+            ),
+            "warnings": forms.widgets.CheckboxSelectMultiple(
+                choices=SHIFT_SLOT_WARNING_CHOICES.items()
+            ),
+        }
+
+    check_update_future_shifts = BooleanField(
+        label=_(
+            "I understand that adding a slot to this ABCD shift will add the slot to all the corresponding future shifts"
+        ),
+        required=True,
+    )

--- a/tapir/shifts/forms.py
+++ b/tapir/shifts/forms.py
@@ -19,6 +19,7 @@ from tapir.shifts.models import (
     ShiftAccountEntry,
     ShiftExemption,
     SHIFT_SLOT_WARNING_CHOICES,
+    ShiftTemplate,
 )
 from tapir.utils.forms import DateInputTapir
 
@@ -189,7 +190,7 @@ class RegisterUserToShiftSlotForm(MissingCapabilitiesWarningMixin):
             and user_to_register.pk != self.request_user.pk
         ):
             raise PermissionDenied(
-                _("You need the shifts.manage permission to do this."), code="invalid"
+                _("You need the shifts.manage permission to do this.")
             )
         if self.slot.shift.slots.filter(attendances__user=user_to_register).exists():
             raise ValidationError(
@@ -329,3 +330,30 @@ class ShiftCancelForm(forms.ModelForm):
     class Meta:
         model = Shift
         fields = ["cancelled_reason"]
+
+
+class ShiftTemplateForm(forms.ModelForm):
+    class Meta:
+        model = ShiftTemplate
+        fields = [
+            "name",
+            "description",
+            "group",
+            "num_required_attendances",
+            "weekday",
+            "start_time",
+            "end_time",
+        ]
+        widgets = {
+            "start_time": forms.widgets.TimeInput(
+                attrs={"type": "time"}, format="%H:%M"
+            ),
+            "end_time": forms.widgets.TimeInput(attrs={"type": "time"}, format="%H:%M"),
+        }
+
+    check_update_future_shifts = BooleanField(
+        label=_(
+            "I understand that updating this ABCD shift will update all the corresponding future shifts"
+        ),
+        required=True,
+    )

--- a/tapir/shifts/models.py
+++ b/tapir/shifts/models.py
@@ -500,12 +500,6 @@ class Shift(models.Model):
             return self.shift_template.num_required_attendances
         return self.num_required_attendances
 
-    def clean(self):
-        if self.start_time >= self.end_time:
-            raise ValidationError(
-                "The start of the shift must be before it's end : " + self.__str__()
-            )
-
     def update_to_fit_template(self):
         date = get_monday(self.start_time.date()) + datetime.timedelta(
             days=self.shift_template.weekday
@@ -517,7 +511,6 @@ class Shift(models.Model):
         self.name = self.shift_template.name
         self.description = self.shift_template.description
         self.num_required_attendances = self.shift_template.num_required_attendances
-        self.clean()
         self.save()
 
 

--- a/tapir/shifts/templates/shifts/shift_template_detail.html
+++ b/tapir/shifts/templates/shifts/shift_template_detail.html
@@ -17,7 +17,7 @@
         <h5 class="card-header d-flex justify-content-between align-items-center">
             <span>{% translate 'ABCD Shift' %}: {{ object.get_display_name }}</span>
             {% if perms.shifts.manage %}
-                <a class="{% tapir_button_link_to_action %}" href="{% url 'admin:shifts_shifttemplate_change' object.pk %}">
+                <a class="{% tapir_button_link_to_action %}" href="{% url 'shifts:shift_template_edit' object.pk %}">
                     <span class="material-icons button-icon">edit</span>
                     {% translate "Edit" %}
                 </a>

--- a/tapir/shifts/templates/shifts/shift_template_detail.html
+++ b/tapir/shifts/templates/shifts/shift_template_detail.html
@@ -17,10 +17,15 @@
         <h5 class="card-header d-flex justify-content-between align-items-center">
             <span>{% translate 'ABCD Shift' %}: {{ object.get_display_name }}</span>
             {% if perms.shifts.manage %}
-                <a class="{% tapir_button_link_to_action %}" href="{% url 'shifts:shift_template_edit' object.pk %}">
-                    <span class="material-icons button-icon">edit</span>
-                    {% translate "Edit" %}
-                </a>
+                <span>
+                    <a class="{% tapir_button_link_to_action %}" href="{% url 'shifts:create_slot_template' object.pk %}">
+                        <span class="material-icons">add_circle_outline</span>{% translate 'Add a slot' %}
+                    </a>
+                    <a class="{% tapir_button_link_to_action %}" href="{% url 'shifts:shift_template_edit' object.pk %}">
+                        <span class="material-icons button-icon">edit</span>
+                        {% translate "Edit" %}
+                    </a>
+                </span>
             {% endif %}
         </h5>
         <ul class="list-group list-group-flush">
@@ -30,7 +35,8 @@
                 </li>
             {% endif %}
             <li class="list-group-item">
-                <table class="{% tapir_table_classes %}" aria-label="{% translate 'List of slots for this ABCD shifts' %}">
+                <table class="{% tapir_table_classes %}"
+                       aria-label="{% translate 'List of slots for this ABCD shifts' %}">
                     <thead>
                     <tr>
                         <th></th>
@@ -72,7 +78,8 @@
                                     <td>
                                         {% if perms.shifts.manage %}
                                             <a class="{% tapir_button_link_to_action %} abcd_shift_register_button"
-                                               href="{% url 'shifts:slottemplate_register' slot.pk %}{% if selected_user %}?selected_user={{ selected_user.pk|urlencode }}{% endif %}">
+                                               href="
+                                                       {% url 'shifts:slottemplate_register' slot.pk %}{% if selected_user %}?selected_user={{ selected_user.pk|urlencode }}{% endif %}">
                                                 <span class="material-icons">person_add</span>
                                                 {% translate "Register" %}
                                             </a>

--- a/tapir/shifts/templates/shifts/shift_template_detail.html
+++ b/tapir/shifts/templates/shifts/shift_template_detail.html
@@ -41,7 +41,11 @@
                     <tr>
                         <th></th>
                         <th>{% translate 'Details' %}</th>
+                        <th>{% translate 'Requirements' %}</th>
                         <th>{% translate 'Registered user' %}</th>
+                        {% if perms.shifts.manage %}
+                            <th>{% translate 'Member-Office actions' %}</th>
+                        {% endif %}
                     </tr>
                     </thead>
                     <tbody>
@@ -50,6 +54,9 @@
                             <td><h5>#{{ forloop.counter }}</h5></td>
                             <td>
                                 {{ slot.name }}
+                            </td>
+                            <td>
+                                {{ slot.get_required_capabilities_display }}
                             </td>
                             {% with slot.attendance_template as attendance %}
                                 {% if attendance %}
@@ -77,7 +84,7 @@
                                 {% else %}
                                     <td>
                                         {% if perms.shifts.manage %}
-                                            <a class="{% tapir_button_link_to_action %} abcd_shift_register_button"
+                                            <a class="{% tapir_button_link_to_action %}"
                                                href="
                                                        {% url 'shifts:slottemplate_register' slot.pk %}{% if selected_user %}?selected_user={{ selected_user.pk|urlencode }}{% endif %}">
                                                 <span class="material-icons">person_add</span>
@@ -87,6 +94,14 @@
                                     </td>
                                 {% endif %}
                             {% endwith %}
+                            <td>
+                                {% if perms.shifts.manage %}
+                                    <a class="{% tapir_button_link_to_action %}" href="{% url 'shifts:edit_slot_template' slot.pk %}">
+                                        <span class="material-icons">edit</span>
+                                        {% translate "Edit" %}
+                                    </a>
+                                {% endif %}
+                            </td>
                         </tr>
                     {% endfor %}
                     </tbody>

--- a/tapir/shifts/tests/factories.py
+++ b/tapir/shifts/tests/factories.py
@@ -47,7 +47,8 @@ class ShiftTemplateFactory(factory.django.DjangoModelFactory):
     def nb_slots(self, create, nb_slots, **kwargs):
         if not create:
             return
-        nb_slots = nb_slots or 1
+        if nb_slots is None:
+            nb_slots = 1
         for _ in range(nb_slots):
             ShiftSlotTemplateFactory.create(shift_template=self)
         self.num_required_attendances = math.ceil(nb_slots / 2)

--- a/tapir/shifts/tests/test_ShiftNames.py
+++ b/tapir/shifts/tests/test_ShiftNames.py
@@ -5,16 +5,16 @@ from tapir.shifts.models import ShiftNames
 
 class ShiftNamesTestCase(unittest.TestCase):
     def test_get_names_for_index(self):
-        self.assertEquals("A", ShiftNames.get_name(0))
-        self.assertEquals("B", ShiftNames.get_name(1))
-        self.assertEquals("C", ShiftNames.get_name(2))
-        self.assertEquals("D", ShiftNames.get_name(3))
+        self.assertEqual("A", ShiftNames.get_name(0))
+        self.assertEqual("B", ShiftNames.get_name(1))
+        self.assertEqual("C", ShiftNames.get_name(2))
+        self.assertEqual("D", ShiftNames.get_name(3))
 
     def test_get_indexes_for_name(self):
-        self.assertEquals(0, ShiftNames.get_index("A"))
-        self.assertEquals(1, ShiftNames.get_index("B"))
-        self.assertEquals(2, ShiftNames.get_index("C"))
-        self.assertEquals(3, ShiftNames.get_index("D"))
+        self.assertEqual(0, ShiftNames.get_index("A"))
+        self.assertEqual(1, ShiftNames.get_index("B"))
+        self.assertEqual(2, ShiftNames.get_index("C"))
+        self.assertEqual(3, ShiftNames.get_index("D"))
 
     def test_unknown_names_cause_index_None(self):
         self.assertIsNone(ShiftNames.get_name(24))

--- a/tapir/shifts/tests/test_shift_reminder.py
+++ b/tapir/shifts/tests/test_shift_reminder.py
@@ -26,7 +26,7 @@ class TestShiftReminder(TapirFactoryTestBase, TapirEmailTestBase):
 
         Command.send_shift_reminder_for_user(user.shift_user_data)
 
-        self.assertEquals(
+        self.assertEqual(
             0,
             len(mail.outbox),
             "A shift that is in the past should not get a reminder even if the reminder has never been sent.",
@@ -45,7 +45,7 @@ class TestShiftReminder(TapirFactoryTestBase, TapirEmailTestBase):
 
         Command.send_shift_reminder_for_user(user.shift_user_data)
 
-        self.assertEquals(
+        self.assertEqual(
             0,
             len(mail.outbox),
             "A shift that is too far in the future should not get a reminder.",
@@ -66,7 +66,7 @@ class TestShiftReminder(TapirFactoryTestBase, TapirEmailTestBase):
 
         Command.send_shift_reminder_for_user(user.shift_user_data)
 
-        self.assertEquals(
+        self.assertEqual(
             1,
             len(mail.outbox),
             "A shift that is in the new future should get a reminder.",

--- a/tapir/shifts/tests/test_shift_template_edit.py
+++ b/tapir/shifts/tests/test_shift_template_edit.py
@@ -1,0 +1,86 @@
+import datetime
+
+from django.urls import reverse
+from django.utils import timezone
+
+from tapir.shifts.models import (
+    ShiftTemplate,
+    ShiftTemplateGroup,
+)
+from tapir.shifts.tests.factories import ShiftTemplateFactory
+from tapir.utils.tests_utils import TapirFactoryTestBase
+
+
+class TestShiftTemplateEdit(TapirFactoryTestBase):
+    SHIFT_TEMPLATE_EDIT_VIEW = "shifts:shift_template_edit"
+
+    def test_after_call_future_shifts_are_updated(self):
+        self.login_as_member_office_user()
+
+        for name in ["A", "B"]:
+            ShiftTemplateGroup.objects.create(name=name)
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create(
+            start_time=datetime.time(hour=6, minute=0),
+            end_time=datetime.time(hour=13, minute=0),
+            num_required_attendances=3,
+            weekday=0,
+        )
+        shift_template.group = ShiftTemplateGroup.objects.get(name="A")
+        shift_template.save()
+
+        shift_1 = shift_template.create_shift(
+            start_date=datetime.date.today() + datetime.timedelta(days=10)
+        )
+        shift_2 = shift_template.create_shift(
+            start_date=datetime.date.today() + datetime.timedelta(days=30)
+        )
+
+        name = "Updated name"
+        description = "Updated description"
+        start_time = datetime.time(hour=11, minute=30)
+        end_time = datetime.time(hour=13, minute=45)
+        num_required_attendances = 4
+        weekday = 1
+        group = ShiftTemplateGroup.objects.get(name="B")
+
+        response = self.client.post(
+            reverse(self.SHIFT_TEMPLATE_EDIT_VIEW, args=[shift_template.pk]),
+            {
+                "name": name,
+                "description": description,
+                "start_time": start_time,
+                "end_time": end_time,
+                "num_required_attendances": num_required_attendances,
+                "group": group.id,
+                "weekday": weekday,
+                "check_update_future_shifts": True,
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        for shift in [shift_1, shift_2]:
+            shift.refresh_from_db()
+            self.assertEqual(name, shift.name)
+            self.assertEqual(description, shift.description)
+            self.assertEqual(start_time, timezone.localtime(shift.start_time).time())
+            self.assertEqual(end_time, timezone.localtime(shift.end_time).time())
+            self.assertEqual(weekday, shift.start_time.weekday())
+            self.assertEqual(num_required_attendances, shift.num_required_attendances)
+
+    def test_not_accessible_for_normal_users(self):
+        self.login_as_normal_user()
+
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create(
+            start_time=datetime.time(hour=6, minute=0),
+            end_time=datetime.time(hour=13, minute=0),
+            num_required_attendances=3,
+            weekday=0,
+        )
+
+        response = self.client.post(
+            reverse(self.SHIFT_TEMPLATE_EDIT_VIEW, args=[shift_template.pk])
+        )
+
+        self.assertEqual(response.status_code, 403)

--- a/tapir/shifts/tests/test_slot_template_create.py
+++ b/tapir/shifts/tests/test_slot_template_create.py
@@ -1,0 +1,91 @@
+import datetime
+
+from django.urls import reverse
+
+from tapir.shifts.models import (
+    ShiftUserCapability,
+    ShiftSlotWarning,
+    ShiftSlot,
+    ShiftTemplate,
+)
+from tapir.shifts.tests.factories import ShiftTemplateFactory
+from tapir.utils.tests_utils import TapirFactoryTestBase
+
+
+class TestSlotTemplateCreate(TapirFactoryTestBase):
+    SLOT_TEMPLATE_CREATE_VIEW = "shifts:create_slot_template"
+    SLOT_TEMPLATE_NAME = "A test name"
+
+    def test_creating_a_slot_template_also_creates_the_slot_in_future_shifts(self):
+        self.login_as_member_office_user()
+
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create(nb_slots=0)
+        shift = shift_template.create_shift(
+            datetime.date.today() + datetime.timedelta(days=10)
+        )
+
+        required_capabilities = [ShiftUserCapability.SHIFT_COORDINATOR]
+        warnings = [ShiftSlotWarning.BREAD_PICKUP_NEEDS_A_VEHICLE]
+
+        response = self.client.post(
+            reverse(self.SLOT_TEMPLATE_CREATE_VIEW, args=[shift_template.id]),
+            {
+                "name": self.SLOT_TEMPLATE_NAME,
+                "required_capabilities": required_capabilities,
+                "warnings": warnings,
+                "check_update_future_shifts": True,
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        shift_template.refresh_from_db()
+        self.assertEqual(shift_template.slot_templates.count(), 1)
+        shift.refresh_from_db()
+        self.assertEqual(shift.slots.count(), 1)
+
+        slot: ShiftSlot = shift.slots.first()
+        self.assertEqual(slot.name, self.SLOT_TEMPLATE_NAME)
+        self.assertEqual(slot.required_capabilities, required_capabilities)
+        self.assertEqual(slot.warnings, warnings)
+
+    def test_normal_user_access_denied(self):
+        self.login_as_normal_user()
+
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create()
+
+        response = self.client.post(
+            reverse(self.SLOT_TEMPLATE_CREATE_VIEW, args=[shift_template.id]),
+            {"name": self.SLOT_TEMPLATE_NAME},
+        )
+
+        self.assertEqual(
+            response.status_code,
+            403,
+            "A user that is not in the member should not have access to shift slot creation.",
+        )
+
+    def test_adding_a_slot_to_the_template_does_not_add_a_slot_to_past_shifts(self):
+        self.login_as_member_office_user()
+
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create(nb_slots=0)
+        shift = shift_template.create_shift(
+            datetime.date.today() - datetime.timedelta(days=10)
+        )
+
+        response = self.client.post(
+            reverse(self.SLOT_TEMPLATE_CREATE_VIEW, args=[shift_template.id]),
+            {
+                "name": self.SLOT_TEMPLATE_NAME,
+                "check_update_future_shifts": True,
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        shift_template.refresh_from_db()
+        self.assertEqual(shift_template.slot_templates.count(), 1)
+        shift.refresh_from_db()
+        self.assertEqual(shift.slots.count(), 0)

--- a/tapir/shifts/tests/test_slot_template_edit.py
+++ b/tapir/shifts/tests/test_slot_template_edit.py
@@ -1,0 +1,103 @@
+import datetime
+
+from django.urls import reverse
+
+from tapir.shifts.models import (
+    ShiftUserCapability,
+    ShiftSlotWarning,
+    ShiftTemplate,
+    ShiftSlotTemplate,
+)
+from tapir.shifts.tests.factories import ShiftTemplateFactory
+from tapir.utils.tests_utils import TapirFactoryTestBase
+
+
+class TestSlotTemplateEdit(TapirFactoryTestBase):
+    SLOT_TEMPLATE_EDIT_VIEW = "shifts:edit_slot_template"
+
+    def test_edit_a_slot_template_also_affects_future_slots(self):
+        self.login_as_member_office_user()
+
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create(nb_slots=1)
+        slot_template: ShiftSlotTemplate = shift_template.slot_templates.first()
+        slot_template.required_capabilities = []
+        slot_template.warnings = []
+        slot_template.save()
+        shift = shift_template.create_shift(
+            datetime.date.today() + datetime.timedelta(days=10)
+        )
+        slot = shift.slots.first()
+        self.assertEqual([], slot.required_capabilities)
+        self.assertEqual([], slot.warnings)
+
+        name = "Name after"
+        required_capabilities = [ShiftUserCapability.SHIFT_COORDINATOR]
+        warnings = [ShiftSlotWarning.BREAD_PICKUP_NEEDS_A_VEHICLE]
+
+        response = self.client.post(
+            reverse(self.SLOT_TEMPLATE_EDIT_VIEW, args=[slot_template.id]),
+            {
+                "name": name,
+                "required_capabilities": required_capabilities,
+                "warnings": warnings,
+                "check_update_future_shifts": True,
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        slot_template.refresh_from_db()
+        self.assertEqual(slot_template.name, name)
+        self.assertEqual(slot_template.required_capabilities, required_capabilities)
+        self.assertEqual(slot_template.warnings, warnings)
+
+        slot.refresh_from_db()
+        self.assertEqual(slot.name, name)
+        self.assertEqual(slot.required_capabilities, required_capabilities)
+        self.assertEqual(slot.warnings, warnings)
+
+    def test_normal_user_access_denied(self):
+        self.login_as_normal_user()
+
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create()
+
+        response = self.client.post(
+            reverse(self.SLOT_TEMPLATE_EDIT_VIEW, args=[shift_template.id]),
+            {"name": "Name after"},
+        )
+
+        self.assertEqual(
+            response.status_code,
+            403,
+            "A user that is not in the member should not have access to slot template edition.",
+        )
+
+    def test_editing_a_slot_template_does_not_affect_past_slots(self):
+        self.login_as_member_office_user()
+
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create(nb_slots=1)
+        slot_template = shift_template.slot_templates.first()
+        slot_template.name = "Name before"
+        slot_template.save()
+        shift = shift_template.create_shift(
+            datetime.date.today() - datetime.timedelta(days=10)
+        )
+        slot = shift.slots.first()
+        self.assertEqual("Name before", slot.name)
+
+        response = self.client.post(
+            reverse(self.SLOT_TEMPLATE_EDIT_VIEW, args=[shift_template.id]),
+            {
+                "name": "Name after",
+                "check_update_future_shifts": True,
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        slot_template.refresh_from_db()
+        self.assertEqual("Name after", slot_template.name)
+        shift.refresh_from_db()
+        self.assertEqual("Name before", slot.name)

--- a/tapir/shifts/urls.py
+++ b/tapir/shifts/urls.py
@@ -167,4 +167,9 @@ urlpatterns = [
         views.ShiftSlotEditView.as_view(),
         name="edit_slot",
     ),
+    path(
+        "slot_template/<int:pk>/edit",
+        views.ShiftSlotTemplateEditView.as_view(),
+        name="edit_slot_template",
+    ),
 ]

--- a/tapir/shifts/urls.py
+++ b/tapir/shifts/urls.py
@@ -33,6 +33,11 @@ urlpatterns = [
         name="shift_edit",
     ),
     path(
+        "shift_template/<int:pk>/edit",
+        views.EditShiftTemplateView.as_view(),
+        name="shift_template_edit",
+    ),
+    path(
         "shift_attendance/<int:pk>/<int:state>",
         views.UpdateShiftAttendanceStateView.as_view(),
         name="update_shift_attendance_state",

--- a/tapir/shifts/urls.py
+++ b/tapir/shifts/urls.py
@@ -38,6 +38,11 @@ urlpatterns = [
         name="shift_template_edit",
     ),
     path(
+        "shift_template/create",
+        views.ShiftTemplateCreateView.as_view(),
+        name="shift_template_create",
+    ),
+    path(
         "shift_attendance/<int:pk>/<int:state>",
         views.UpdateShiftAttendanceStateView.as_view(),
         name="update_shift_attendance_state",
@@ -151,6 +156,11 @@ urlpatterns = [
         "shift/<int:shift_pk>/slot/create",
         views.ShiftSlotCreateView.as_view(),
         name="create_slot",
+    ),
+    path(
+        "shift_template/<int:shift_pk>/slot_template/create",
+        views.ShiftSlotTemplateCreateView.as_view(),
+        name="create_slot_template",
     ),
     path(
         "slot/<int:pk>/edit",

--- a/tapir/utils/shortcuts.py
+++ b/tapir/utils/shortcuts.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.http import HttpResponse
 from django.shortcuts import redirect
+from django.utils import timezone
 from django.utils.encoding import iri_to_uri
 from django.utils.html import format_html
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -40,3 +41,10 @@ def set_header_for_file_download(response: HttpResponse, filename: str):
 
 def get_html_link(url: str, text: str):
     return format_html("<a href={}>{}</a>", url, text)
+
+
+def get_timezone_aware_datetime(
+    date: datetime.date, time: datetime.time
+) -> datetime.datetime:
+    result = datetime.datetime.combine(date, time)
+    return timezone.make_aware(result)


### PR DESCRIPTION
Hey,

Since we had requests again to update ABCD shifts, I thought I'd try to allow people to do it themselves.
You can then create and edit ABCD shifts, also add slots to ABCD shifts.

I'm deploying this to test and live today.