### PR TITLE
Use settings from .env file in docker-compose.yml and tapir/settings.py

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,9 @@
-/venv
-/.venv
 /.pytest_cache
 /.idea
 /.github
+
+# Environments
+.env*
+!.env.example
+/venv
+/.venv

--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,32 @@ POSTGRES_USER=tapir
 VIRTUAL_HOST=localhost
 HTTPS_METHOD=noredirect
 DEFAULT_HOST=localhost
+
+
+#
+# tapir/settings.py
+#
+TAPIR_SITE_URL=http://127.0.0.1:8000
+TAPIR_SECRET_KEY=use_your_own_secret_key_and_generate_a_good_one!!!
+TAPIR_DEBUG=1
+TAPIR_ALLOWED_HOSTS=*
+TAPIR_ENABLE_API=False
+TAPIR_DJANGO_ADMINS=
+
+TAPIR_DATABASE_URL=postgresql://tapir:tapir@db:5432/tapir
+TAPIR_LDAP_URL=ldap://cn=admin,dc=supercoop,dc=de:admin@openldap
+
+TAPIR_COOP_NAME=SuperCoop Berlin
+TAPIR_COOP_FULL_NAME=SuperCoop Berlin eG
+TAPIR_COOP_STREET=Oudenarder Straße 16
+TAPIR_COOP_PLACE=13347 Berlin
+
+TAPIR_EMAIL_ENV=dev
+TAPIR_EMAIL_HOST=smtp-relay.gmail.com
+TAPIR_EMAIL_HOST_USER=mitglied@supercoop.de
+TAPIR_EMAIL_HOST_PASSWORD=
+TAPIR_EMAIL_ADDRESS_MEMBER_OFFICE=mitglied@supercoop.de
+TAPIR_EMAIL_ADDRESS_ACCOUNTING=accounting@supercoop.de
+TAPIR_EMAIL_ADDRESS_MANAGEMENT=contact@supercoop.de
+TAPIR_EMAIL_ADDRESS_SUPERVISORS=aufsichtsrat@supercoop.de
+TAPIR_SERVER_EMAIL=mitglied@supercoop.de

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+#
+# Debug flag
+#
+DEBUG=1
+
+
+#
+# LDAP
+#
+LDAP_ORGANISATION=SuperCoop Berlin
+LDAP_DOMAIN=supercoop.de
+LDAP_ADMIN_PASSWORD=admin
+LDAP_READONLY_USER=true
+
+
+#
+# Database
+#
+POSTGRES_DB=tapir
+POSTGRES_PASSWORD=tapir
+POSTGRES_USER=tapir
+
+
+#
+# Hosts/Http
+#
+VIRTUAL_HOST=localhost
+HTTPS_METHOD=noredirect
+DEFAULT_HOST=localhost

--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,8 @@ celerybeat-schedule.*
 *.sage.py
 
 # Environments
-.env
+.env*
+!.env.example
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -21,14 +21,17 @@ SuperCoop members can access the system at [https://members.supercoop.de](https:
 ## Getting started
 
 ### Prerequisites
-- Docker 
+
+- Docker
 - [Poetry](https://python-poetry.org/docs/)
 
 Please note that while the actual program runs in a Docker container, you're adviced to install packages locally in order to use your IDE properly. For that you need a C Compiler such as gcc for Linux or the Visual C++ Build tools.
+
 ### Install
 
 1. Clone the project.
 2. Configure our pre-commit hooks: `poetry install && pre-commit install`
+3. Copy the .env template file: `cp .env.example .env`
 
 ### Setup
 
@@ -68,5 +71,5 @@ You can do so **without any programming or Python knowledge**! Just choose a tas
 
 ## Troubleshooting
 
-* On macOS, in order to set up a local Python `venv`, you might have to install Postgresql to get `psycopg2` working.
-  Use `brew install postgresql` for that. 
+- On macOS, in order to set up a local Python `venv`, you might have to install Postgresql to get `psycopg2` working.
+  Use `brew install postgresql` for that.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,8 @@ version: "3.9"
 services:
   openldap:
     image: "osixia/openldap"
-    environment:
-      LDAP_ORGANISATION: "SuperCoop Berlin"
-      LDAP_DOMAIN: "supercoop.de"
-      LDAP_ADMIN_PASSWORD: "admin"
-      LDAP_READONLY_USER: "true"
+    env_file:
+      - .env
     ports:
       - "389:389"
     volumes:
@@ -21,9 +18,8 @@ services:
                       poetry run python manage.py runserver_plus 0.0.0.0:80"
     volumes:
       - .:/app
-    environment:
-      VIRTUAL_HOST: localhost
-      DEBUG: 1
+    env_file:
+      - .env
     depends_on:
       - openldap
       - db
@@ -39,16 +35,14 @@ services:
     ports:
       - "8000:80"
       - "8001:443"
-    environment:
-      HTTPS_METHOD: noredirect
-      DEFAULT_HOST: localhost
+    env_file:
+      - .env
+
 
   db:
     image: postgres:14-alpine
-    environment:
-      - POSTGRES_DB=tapir
-      - POSTGRES_PASSWORD=tapir
-      - POSTGRES_USER=tapir
+    env_file:
+      - .env
     ports:
       - '5432:5432'
 
@@ -68,8 +62,8 @@ services:
                       poetry run celery -A tapir worker -l info"
     volumes:
       - .:/app
-    environment:
-      DEBUG: 1
+    env_file:
+      - .env
     depends_on:
       - redis
 
@@ -80,8 +74,8 @@ services:
                       poetry run celery -A tapir beat -l info --schedule /tmp/celerybeat-schedule"
     volumes:
       - .:/app
-    environment:
-      DEBUG: 1
+    env_file:
+      - .env
     depends_on:
       - redis
 

--- a/tapir/settings.py
+++ b/tapir/settings.py
@@ -17,10 +17,16 @@ from pathlib import Path
 import celery.schedules
 import environ
 
-env = environ.Env()
+env = environ.Env(
+    # Set casting and default value
+    DEBUG=(bool, False)
+)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Take environment variables from .env file
+environ.Env.read_env(os.path.join(BASE_DIR, ".env"))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
@@ -29,7 +35,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = env("TAPIR_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = env("TAPIR_DEBUG", cast=bool, default=False)
+# False by default if not in os.environ because of casting above
+DEBUG = env("TAPIR_DEBUG")
 
 ALLOWED_HOSTS = env("TAPIR_ALLOWED_HOSTS", cast=list)
 

--- a/tapir/settings.py
+++ b/tapir/settings.py
@@ -26,14 +26,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env(
-    "TAPIR_SECRET_KEY", default="fl%20e9dbkh4mosi5$i$!5&+f^ic5=7^92hrchl89x+)k0ctsn"
-)
+SECRET_KEY = env("TAPIR_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("TAPIR_DEBUG", cast=bool, default=False)
 
-ALLOWED_HOSTS = env("TAPIR_ALLOWED_HOSTS", cast=list, default=["*"])
+ALLOWED_HOSTS = env("TAPIR_ALLOWED_HOSTS", cast=list)
 
 ENABLE_SILK_PROFILING = False
 ENABLE_API = env("TAPIR_ENABLE_API", cast=bool, default=False)
@@ -126,12 +124,8 @@ WSGI_APPLICATION = "tapir.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 DATABASES = {
-    "default": env.db(
-        "TAPIR_DATABASE_URL", default="postgresql://tapir:tapir@db:5432/tapir"
-    ),
-    "ldap": env.db_url(
-        "TAPIR_LDAP_URL", default="ldap://cn=admin,dc=supercoop,dc=de:admin@openldap"
-    ),
+    "default": env.db("TAPIR_DATABASE_URL"),
+    "ldap": env.db_url("TAPIR_LDAP_URL"),
 }
 
 DATABASE_ROUTERS = ["ldapdb.router.Router"]
@@ -205,7 +199,7 @@ if EMAIL_ENV == "dev" or EMAIL_ENV == "test":
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 elif EMAIL_ENV == "prod":
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-    EMAIL_HOST = env("TAPIR_EMAIL_HOST", default="smtp-relay.gmail.com")
+    EMAIL_HOST = env("TAPIR_EMAIL_HOST")
     EMAIL_HOST_USER = env("TAPIR_EMAIL_HOST_USER", default=EMAIL_ADDRESS_MEMBER_OFFICE)
     EMAIL_HOST_PASSWORD = env("TAPIR_EMAIL_HOST_PASSWORD")
     EMAIL_PORT = 587

--- a/tapir/settings.py
+++ b/tapir/settings.py
@@ -27,16 +27,16 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env(
-    "SECRET_KEY", default="fl%20e9dbkh4mosi5$i$!5&+f^ic5=7^92hrchl89x+)k0ctsn"
+    "TAPIR_SECRET_KEY", default="fl%20e9dbkh4mosi5$i$!5&+f^ic5=7^92hrchl89x+)k0ctsn"
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = env("DEBUG", cast=bool, default=False)
+DEBUG = env("TAPIR_DEBUG", cast=bool, default=False)
 
-ALLOWED_HOSTS = env("ALLOWED_HOSTS", cast=list, default=["*"])
+ALLOWED_HOSTS = env("TAPIR_ALLOWED_HOSTS", cast=list, default=["*"])
 
 ENABLE_SILK_PROFILING = False
-ENABLE_API = env("ENABLE_API", cast=bool, default=False)
+ENABLE_API = env("TAPIR_ENABLE_API", cast=bool, default=False)
 
 # Application definition
 INSTALLED_APPS = [
@@ -126,9 +126,11 @@ WSGI_APPLICATION = "tapir.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 DATABASES = {
-    "default": env.db(default="postgresql://tapir:tapir@db:5432/tapir"),
+    "default": env.db(
+        "TAPIR_DATABASE_URL", default="postgresql://tapir:tapir@db:5432/tapir"
+    ),
     "ldap": env.db_url(
-        "LDAP_URL", default="ldap://cn=admin,dc=supercoop,dc=de:admin@openldap"
+        "TAPIR_LDAP_URL", default="ldap://cn=admin,dc=supercoop,dc=de:admin@openldap"
     ),
 }
 
@@ -192,37 +194,39 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
-EMAIL_ADDRESS_MEMBER_OFFICE = "mitglied@supercoop.de"
-EMAIL_ADDRESS_ACCOUNTING = "accounting@supercoop.de"
-EMAIL_ADDRESS_MANAGEMENT = "contact@supercoop.de"
-EMAIL_ADDRESS_SUPERVISORS = "aufsichtsrat@supercoop.de"
+EMAIL_ADDRESS_MEMBER_OFFICE = env("TAPIR_EMAIL_ADDRESS_MEMBER_OFFICE")
+EMAIL_ADDRESS_ACCOUNTING = env("TAPIR_EMAIL_ADDRESS_ACCOUNTING")
+EMAIL_ADDRESS_MANAGEMENT = env("TAPIR_EMAIL_ADDRESS_MANAGEMENT")
+EMAIL_ADDRESS_SUPERVISORS = env("TAPIR_EMAIL_ADDRESS_SUPERVISORS")
 
 # django-environ EMAIL_URL mechanism is a bit hairy with passwords with slashes in them, so use this instead
-EMAIL_ENV = env("EMAIL_ENV", default="dev")
+EMAIL_ENV = env("TAPIR_EMAIL_ENV", default="dev")
 if EMAIL_ENV == "dev" or EMAIL_ENV == "test":
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 elif EMAIL_ENV == "prod":
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-    EMAIL_HOST = env("EMAIL_HOST", default="smtp-relay.gmail.com")
-    EMAIL_HOST_USER = env("EMAIL_HOST_USER", default=EMAIL_ADDRESS_MEMBER_OFFICE)
-    EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD")
+    EMAIL_HOST = env("TAPIR_EMAIL_HOST", default="smtp-relay.gmail.com")
+    EMAIL_HOST_USER = env("TAPIR_EMAIL_HOST_USER", default=EMAIL_ADDRESS_MEMBER_OFFICE)
+    EMAIL_HOST_PASSWORD = env("TAPIR_EMAIL_HOST_PASSWORD")
     EMAIL_PORT = 587
     EMAIL_USE_TLS = True
 
 
-COOP_NAME = "SuperCoop Berlin"
-COOP_FULL_NAME = "SuperCoop Berlin eG"
-COOP_STREET = "Oudenarder Straße 16"
-COOP_PLACE = "13347 Berlin"
+COOP_NAME = env("TAPIR_COOP_NAME")
+COOP_FULL_NAME = env("TAPIR_COOP_FULL_NAME")
+COOP_STREET = env("TAPIR_COOP_STREET")
+COOP_PLACE = env("TAPIR_COOP_PLACE")
 FROM_EMAIL_MEMBER_OFFICE = f"{COOP_NAME} Mitgliederbüro <{EMAIL_ADDRESS_MEMBER_OFFICE}>"
 DEFAULT_FROM_EMAIL = FROM_EMAIL_MEMBER_OFFICE
 
 
 # DJANGO_ADMINS="Blake <blake@cyb.org>, Alice Judge <alice@cyb.org>"
-ADMINS = tuple(email.utils.parseaddr(x) for x in env.list("DJANGO_ADMINS", default=[]))
+ADMINS = tuple(
+    email.utils.parseaddr(x) for x in env.list("TAPIR_DJANGO_ADMINS", default=[])
+)
 # Crash emails will come from this address.
 # NOTE(Leon Handreke): I don't know if our Google SMTP will reject other senders, so play it safe.
-SERVER_EMAIL = env("SERVER_EMAIL", default=EMAIL_ADDRESS_MEMBER_OFFICE)
+SERVER_EMAIL = env("TAPIR_SERVER_EMAIL", default=EMAIL_ADDRESS_MEMBER_OFFICE)
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
@@ -271,7 +275,7 @@ CLIENT_PERMISSIONS = {
 AUTH_USER_MODEL = "accounts.TapirUser"
 LOGIN_REDIRECT_URL = "accounts:user_me"
 
-SITE_URL = env("SITE_URL", default="http://127.0.0.1:8000")
+SITE_URL = env("TAPIR_SITE_URL", default="http://127.0.0.1:8000")
 
 PHONENUMBER_DEFAULT_REGION = "DE"
 


### PR DESCRIPTION
I'd like to request to switch to a workflow based on an untracked .env file.

### Why I suggest this

When getting started with tapir I wanted to test a cloud based Postgres service instead of using the db Docker container. But I didn't want to expose my database url in `docker-compose.yml` or `tapir/settings.py` from the beginning. So I used an `.env` file and thought it might make sense to move more of the hard-coded settings in there.

As the `.env` must be kept untracked I added a tracked `.env.example` file which pretty much has all of the hard-coded settings to get tapir up and running, but can be easily changed with your own settings. The `README.md` is updated to reflect those changes (just a simple one-liner). 