### PR TITLE
Improve docker configuration and remove command redundancies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.10
+ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 COPY . /app
 
 RUN apt update -y && apt install -y libldap2-dev libsasl2-dev gettext
-
-RUN pip install poetry && poetry install && poetry run python manage.py compilemessages
+RUN pip install poetry && poetry install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,7 @@ services:
 
   web:
     build: .
-    command: bash -c "poetry install &&
-                      poetry run python manage.py compilemessages --ignore \".venv\" &&
-                      poetry run python manage.py runserver_plus 0.0.0.0:80"
+    command: bash -c "poetry run python manage.py compilemessages --ignore \".venv\" && poetry run python manage.py runserver_plus 0.0.0.0:80"
     volumes:
       - .:/app
     environment:
@@ -64,8 +62,7 @@ services:
 
   celery:
     build: .
-    command: bash -c "poetry install &&
-                      poetry run celery -A tapir worker -l info"
+    command: bash -c "poetry run celery -A tapir worker -l info"
     volumes:
       - .:/app
     environment:
@@ -76,8 +73,7 @@ services:
   celery-beat:
     build: .
     # --schedule to avoid polluting the app directory
-    command: bash -c "poetry install &&
-                      poetry run celery -A tapir beat -l info --schedule /tmp/celerybeat-schedule"
+    command: bash -c "poetry run celery -A tapir beat -l info --schedule /tmp/celerybeat-schedule"
     volumes:
       - .:/app
     environment:


### PR DESCRIPTION
I would like to request a few small changes in the Docker configuration. In my opinion it is an unnecessary redundancy to call `poetry install` in `Dockerfile` and also in `docker-compose.yml` file. There is also a `RUN` command `poetry run python manage.py compilemessages` which I guess is only relevant for the `web`container (which runs `poetry run python manage.py compilemessages --ignore \".venv\"` when started).

Apart from that I would argument that the `RUN` command should install dependencies or set up the environment for an image whereas project/app specific commands like `poetry run ...` should use the `command` key in the `docker-compose.yml` file. 

I don't know if I've taken everything into account. What do you think?