### PR TITLE
Add chart with average basket price

### DIFF
--- a/tapir/accounts/templates/accounts/user_detail.html
+++ b/tapir/accounts/templates/accounts/user_detail.html
@@ -14,6 +14,8 @@
 {% block head %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'shifts/css/shifts.css' %}">
+<script src="{% static 'statistics/chart_4.4.0.js' %}"></script>
+<script src="{% static 'statistics/tapir_charts.js' %}" defer></script>
 {% endblock %}
 
 {% block title %}

--- a/tapir/statistics/templates/statistics/tags/purchase_statistics_card.html
+++ b/tapir/statistics/templates/statistics/tags/purchase_statistics_card.html
@@ -31,4 +31,18 @@
             </table>
         </li>
     </ul>
+    <div class="card-body">
+        <p>
+                <span class="{% tapir_button_link %}"
+                      onclick="chartManager.show_stats_chart(
+                              this,
+                              '{% url "statistics:average_basket_evolution_json" tapir_user.pk %}',
+                              'average_basket_evolution_canvas',
+                )">
+            <span class="material-icons">leaderboard</span>
+            <span class="button-text">{% translate "Show graph: " %}{% translate "Evolution of average basket price" %}</span>
+            </span>
+            <canvas id="average_basket_evolution_canvas" style="display: none;"></canvas>
+        </p>
+    </div>
 </div>

--- a/tapir/statistics/urls.py
+++ b/tapir/statistics/urls.py
@@ -39,4 +39,9 @@ urlpatterns = [
         views.UpdatePurchaseDataManuallyView.as_view(),
         name="update_purchase_data_manually",
     ),
+    path(
+        "user/<int:pk>/average_basket_evolution_json",
+        views.AverageBasketEvolutionJsonView.as_view(),
+        name="average_basket_evolution_json",
+    ),
 ]

--- a/tapir/statistics/views.py
+++ b/tapir/statistics/views.py
@@ -1,18 +1,26 @@
 import datetime
 
+from dateutil.relativedelta import relativedelta
+
 from chartjs.views import JSONView
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.core.management import call_command
-from django.db.models import Sum
+from django.db.models import Avg, Sum
+from django.db.models.functions import TruncMonth
+from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from django.views.generic import RedirectView
+from pytz import utc
 
-from tapir.accounts.models import UpdateTapirUserLogEntry
+from tapir.accounts.models import (
+    TapirUser,
+    UpdateTapirUserLogEntry,
+)
 from tapir.coop.models import ShareOwnership, ShareOwner, MemberStatus
 from tapir.coop.views import ShareCountEvolutionJsonView
 from tapir.financingcampaign.models import (
@@ -26,7 +34,10 @@ from tapir.shifts.models import (
     ShiftAttendanceMode,
 )
 from tapir.shifts.services.shift_expectation_service import ShiftExpectationService
-from tapir.statistics.models import ProcessedPurchaseFiles
+from tapir.statistics.models import (
+    PurchaseBasket,
+    ProcessedPurchaseFiles,
+)
 from tapir.statistics.utils import (
     build_pie_chart_data,
     build_line_chart_data,
@@ -204,6 +215,62 @@ class NewMembersPerMonthJsonView(CacheDatesFromFirstShareToTodayMixin, JSONView)
             },
         }
         return context_data
+
+
+class AverageBasketEvolutionJsonView(LoginRequiredMixin, JSONView):
+    def get_context_data(self, **kwargs):
+        tapir_user = get_object_or_404(TapirUser, pk=(self.kwargs["pk"]))
+        logged_user = self.request.user
+        if tapir_user.pk != logged_user.pk and not logged_user.has_perm(
+            PERMISSION_COOP_MANAGE
+        ):
+            return HttpResponseForbidden("Access forbidden")
+
+        user_purchases = (
+            PurchaseBasket.objects.filter(tapir_user=tapir_user)
+            .annotate(month=TruncMonth("purchase_date"))
+            .values("month")
+            .annotate(average_gross_amount=Avg("gross_amount"))
+            .order_by("month")
+        )
+
+        months = self.get_months(user_purchases)
+
+        return build_line_chart_data(
+            x_axis_values=months,
+            y_axis_values=[self.get_avg_price_per_month(user_purchases, months)],
+            data_labels=[_("Price of average basket")],
+        )
+
+    @staticmethod
+    def get_months(user_purchases):
+        months = []
+        if len(user_purchases) > 0:
+            now = datetime.datetime.now().replace(
+                day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=utc
+            )
+
+            month = user_purchases[0]["month"].replace(tzinfo=utc)
+            months.append(month.strftime("%Y-%m"))
+
+            while month != now:
+                month = month + relativedelta(months=1)
+                months.append(month.strftime("%Y-%m"))
+
+        return months
+
+    @staticmethod
+    def get_avg_price_per_month(purchases_query_set, months):
+        prices = []
+        if len(purchases_query_set) > 0:
+            purchases_dict = {
+                entry["month"].strftime("%Y-%m"): entry["average_gross_amount"]
+                for entry in purchases_query_set
+            }
+            for month in months:
+                prices.append(purchases_dict.get(month, 0))
+
+        return prices
 
 
 class FrozenMembersJsonView(JSONView):


### PR DESCRIPTION
This adds a new graph:

![image](https://github.com/SuperCoopBerlin/tapir/assets/1138746/731eec5e-5bbf-406a-afad-f2f52d5098b3)

Testing it requires some data:
```
INSERT INTO "public"."statistics_processedpurchasefiles" ("id", "file_name", "processed_on") VALUES
(1, 'test', '2023-11-27 18:02:48.434505+00');
INSERT INTO "public"."statistics_purchasebasket" ("id", "purchase_date", "cashier", "purchase_counter", "gross_amount", "first_net_amount", "second_net_amount", "discount", "source_file_id", "tapir_user_id") VALUES
(3, '2023-11-27 18:02:48.434505+00', 1000, 2000, 28.88, 20, 20, 0, 1, 1066),
(4, '2023-11-01 18:02:48.434505+00', 1000, 2000, 28.88, 20, 20, 0, 1, 1066),
(5, '2023-10-27 18:02:48.434505+00', 1000, 2000, 28.88, 20, 20, 0, 1, 1066),
(6, '2023-10-27 18:02:48.434505+00', 1000, 2000, 128.88, 20, 20, 0, 1, 1066),
(7, '2023-07-27 18:02:48.434505+00', 1000, 2000, 28.88, 20, 20, 0, 1, 1066),
(8, '2023-07-27 18:02:48.434505+00', 1000, 2000, 28.88, 20, 20, 0, 1, 1065);
```
And then you can go to: http://localhost:8000/accounts/user/1066/