### PR TITLE
Fix tests depending on year 2024

### DIFF
--- a/tapir/coop/models.py
+++ b/tapir/coop/models.py
@@ -108,7 +108,7 @@ class ShareOwner(models.Model):
 
         def with_status(self, status: str, date=None):
             if date is None:
-                date = datetime.date.today()
+                date = timezone.now()
             active_ownerships = ShareOwnership.objects.active_temporal(date)
 
             if status == MemberStatus.SOLD:

--- a/tapir/coop/tests/test_MemberStatus.py
+++ b/tapir/coop/tests/test_MemberStatus.py
@@ -11,7 +11,6 @@ from tapir.coop.models import (
 )
 from tapir.coop.tests.factories import ShareOwnerFactory, MembershipPauseFactory
 from tapir.utils.tests_utils import TapirFactoryTestBase
-from tapir.utils.tests_utils import mock_timezone_now
 
 
 class ShareOwnerStatusBaseTestClass(ABC):
@@ -36,7 +35,6 @@ class ShareOwnerStatusBaseTestClass(ABC):
         share.start_date = datetime.date(year=2020, month=1, day=1)
         share.end_date = datetime.date(year=2022, month=1, day=1)
         share.save()
-        mock_timezone_now(self, datetime.datetime(year=2023, month=1, day=1))
         self.assertMemberStatus(share_owner, MemberStatus.SOLD)
 
     def test_hasFutureShares_returnsSold(self):
@@ -44,9 +42,8 @@ class ShareOwnerStatusBaseTestClass(ABC):
             nb_shares=1, is_investing=False
         )
         share: ShareOwnership = share_owner.share_ownerships.first()
-        share.start_date = datetime.date(year=2024, month=1, day=1)
+        share.start_date = datetime.date(year=3024, month=1, day=1)
         share.save()
-        mock_timezone_now(self, datetime.datetime(year=2023, month=1, day=1))
         self.assertMemberStatus(share_owner, MemberStatus.SOLD)
 
     def test_hasNoSharesAndIsInvesting_returnsSold(self):
@@ -70,7 +67,6 @@ class ShareOwnerStatusBaseTestClass(ABC):
             start_date=datetime.date(year=2022, month=1, day=1),
             end_date=datetime.date(year=2024, month=1, day=1),
         )
-        mock_timezone_now(self, datetime.datetime(year=2023, month=1, day=1))
         self.assertMemberStatus(share_owner, MemberStatus.INVESTING)
 
     def test_isPaused_returnsPaused(self):
@@ -80,9 +76,8 @@ class ShareOwnerStatusBaseTestClass(ABC):
         MembershipPauseFactory.create(
             share_owner=share_owner,
             start_date=datetime.date(year=2022, month=1, day=1),
-            end_date=datetime.date(year=2024, month=1, day=1),
+            end_date=datetime.date(year=2124, month=1, day=1),
         )
-        mock_timezone_now(self, datetime.datetime(year=2023, month=1, day=1))
         self.assertMemberStatus(share_owner, MemberStatus.PAUSED)
 
     def test_hasInvactivePause_returnsActive(self):
@@ -94,7 +89,6 @@ class ShareOwnerStatusBaseTestClass(ABC):
             start_date=datetime.date(year=2020, month=1, day=1),
             end_date=datetime.date(year=2022, month=1, day=1),
         )
-        mock_timezone_now(self, datetime.datetime(year=2023, month=1, day=1))
         self.assertMemberStatus(share_owner, MemberStatus.ACTIVE)
 
     def test_default_returnsActive(self):

--- a/tapir/coop/tests/test_MemberStatus.py
+++ b/tapir/coop/tests/test_MemberStatus.py
@@ -11,6 +11,7 @@ from tapir.coop.models import (
 )
 from tapir.coop.tests.factories import ShareOwnerFactory, MembershipPauseFactory
 from tapir.utils.tests_utils import TapirFactoryTestBase
+from tapir.utils.tests_utils import mock_timezone_now
 
 
 class ShareOwnerStatusBaseTestClass(ABC):
@@ -35,6 +36,7 @@ class ShareOwnerStatusBaseTestClass(ABC):
         share.start_date = datetime.date(year=2020, month=1, day=1)
         share.end_date = datetime.date(year=2022, month=1, day=1)
         share.save()
+        mock_timezone_now(self, datetime.datetime(year=2023, month=1, day=1))
         self.assertMemberStatus(share_owner, MemberStatus.SOLD)
 
     def test_hasFutureShares_returnsSold(self):
@@ -42,8 +44,9 @@ class ShareOwnerStatusBaseTestClass(ABC):
             nb_shares=1, is_investing=False
         )
         share: ShareOwnership = share_owner.share_ownerships.first()
-        share.start_date = datetime.date(year=3024, month=1, day=1)
+        share.start_date = datetime.date(year=2024, month=1, day=1)
         share.save()
+        mock_timezone_now(self, datetime.datetime(year=2023, month=1, day=1))
         self.assertMemberStatus(share_owner, MemberStatus.SOLD)
 
     def test_hasNoSharesAndIsInvesting_returnsSold(self):
@@ -67,6 +70,7 @@ class ShareOwnerStatusBaseTestClass(ABC):
             start_date=datetime.date(year=2022, month=1, day=1),
             end_date=datetime.date(year=2024, month=1, day=1),
         )
+        mock_timezone_now(self, datetime.datetime(year=2023, month=1, day=1))
         self.assertMemberStatus(share_owner, MemberStatus.INVESTING)
 
     def test_isPaused_returnsPaused(self):
@@ -76,8 +80,9 @@ class ShareOwnerStatusBaseTestClass(ABC):
         MembershipPauseFactory.create(
             share_owner=share_owner,
             start_date=datetime.date(year=2022, month=1, day=1),
-            end_date=datetime.date(year=2124, month=1, day=1),
+            end_date=datetime.date(year=2024, month=1, day=1),
         )
+        mock_timezone_now(self, datetime.datetime(year=2023, month=1, day=1))
         self.assertMemberStatus(share_owner, MemberStatus.PAUSED)
 
     def test_hasInvactivePause_returnsActive(self):
@@ -89,6 +94,7 @@ class ShareOwnerStatusBaseTestClass(ABC):
             start_date=datetime.date(year=2020, month=1, day=1),
             end_date=datetime.date(year=2022, month=1, day=1),
         )
+        mock_timezone_now(self, datetime.datetime(year=2023, month=1, day=1))
         self.assertMemberStatus(share_owner, MemberStatus.ACTIVE)
 
     def test_default_returnsActive(self):

--- a/tapir/shifts/tests/test_slot_template_edit.py
+++ b/tapir/shifts/tests/test_slot_template_edit.py
@@ -87,7 +87,7 @@ class TestSlotTemplateEdit(TapirFactoryTestBase):
         self.assertEqual("Name before", slot.name)
 
         response = self.client.post(
-            reverse(self.SLOT_TEMPLATE_EDIT_VIEW, args=[shift_template.id]),
+            reverse(self.SLOT_TEMPLATE_EDIT_VIEW, args=[slot_template.id]),
             {
                 "name": "Name after",
                 "check_update_future_shifts": True,

--- a/tapir/utils/models.py
+++ b/tapir/utils/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from datetime import date
 
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -299,7 +298,7 @@ class DurationModelMixinQuerySet(models.QuerySet):
     def active_temporal(self, effective_date=None) -> DurationModelMixinQuerySet:
         if not effective_date:
             # if no effective date was given, use today as the default
-            effective_date = date.today()
+            effective_date = timezone.now()
         return self.overlapping_with(
             # It's impossible to instantiate an abstract model, therefore create a namedtuple here
             namedtuple("FakeDurationModelMixin", ["start_date", "end_date"])(

--- a/tapir/welcomedesk/tests/test_welcome_desk_messages.py
+++ b/tapir/welcomedesk/tests/test_welcome_desk_messages.py
@@ -11,7 +11,7 @@ from tapir.shifts.models import (
     ShiftAttendanceTemplate,
     ShiftExemption,
 )
-from tapir.utils.tests_utils import TapirFactoryTestBase
+from tapir.utils.tests_utils import TapirFactoryTestBase, mock_timezone_now
 from tapir.utils.user_utils import UserUtils
 
 
@@ -57,8 +57,9 @@ class TestWelcomeDeskMessages(TapirFactoryTestBase):
         MembershipPauseFactory.create(
             share_owner=user.share_owner,
             start_date=datetime.date(year=2022, month=1, day=1),
-            end_date=datetime.date(year=3024, month=1, day=1),
+            end_date=datetime.date(year=2024, month=1, day=1),
         )
+        mock_timezone_now(self, datetime.datetime(year=2024, month=1, day=1))
         self.check_alerts(user.share_owner, [self.Messages.IS_PAUSED])
 
     def test_no_abcd_shift(self):

--- a/tapir/welcomedesk/tests/test_welcome_desk_messages.py
+++ b/tapir/welcomedesk/tests/test_welcome_desk_messages.py
@@ -8,11 +8,10 @@ from tapir.coop.models import ShareOwner
 from tapir.coop.tests.factories import ShareOwnerFactory, MembershipPauseFactory
 from tapir.shifts.models import (
     ShiftAttendanceMode,
-    ShiftAccountEntry,
     ShiftAttendanceTemplate,
     ShiftExemption,
 )
-from tapir.utils.tests_utils import TapirFactoryTestBase, mock_timezone_now
+from tapir.utils.tests_utils import TapirFactoryTestBase
 from tapir.utils.user_utils import UserUtils
 
 
@@ -58,9 +57,8 @@ class TestWelcomeDeskMessages(TapirFactoryTestBase):
         MembershipPauseFactory.create(
             share_owner=user.share_owner,
             start_date=datetime.date(year=2022, month=1, day=1),
-            end_date=datetime.date(year=2024, month=1, day=1),
+            end_date=datetime.date(year=3024, month=1, day=1),
         )
-        mock_timezone_now(self, datetime.datetime(year=2024, month=1, day=1))
         self.check_alerts(user.share_owner, [self.Messages.IS_PAUSED])
 
     def test_no_abcd_shift(self):


### PR DESCRIPTION
The correct way of getting time is: `timezone.now()`.
> This function is preferred over [today()](https://docs.python.org/3/library/datetime.html#datetime.datetime.today) and [utcnow()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow).

(source: https://docs.python.org/3/library/datetime.html#datetime.datetime.now)