### PR TITLE
Fix unregistered task error from Celery

### DIFF
--- a/tapir/accounts/tasks.py
+++ b/tapir/accounts/tasks.py
@@ -5,3 +5,8 @@ from django.core.management import call_command
 @shared_task
 def update_purchase_tracking_list():
     call_command("update_purchase_tracking_list")
+
+
+@shared_task
+def send_create_account_reminder():
+    call_command("send_create_account_reminder")

--- a/tapir/shifts/tasks.py
+++ b/tapir/shifts/tasks.py
@@ -20,8 +20,3 @@ def generate_shifts():
 @shared_task
 def run_freeze_checks():
     call_command("run_freeze_checks")
-
-
-@shared_task
-def send_create_account_reminder():
-    call_command("send_create_account_reminder")

--- a/tapir/shifts/tasks.py
+++ b/tapir/shifts/tasks.py
@@ -20,3 +20,8 @@ def generate_shifts():
 @shared_task
 def run_freeze_checks():
     call_command("run_freeze_checks")
+
+
+@shared_task
+def send_create_account_reminder():
+    call_command("send_create_account_reminder")


### PR DESCRIPTION
In the logs of Celery container I saw this error. The MR should fix it.
```
[2024-02-27 12:00:00,017: ERROR/MainProcess] Received unregistered task of type 'tapir.accounts.tasks.send_create_account_reminder'.
The message has been ignored and discarded.

Did you remember to import the module containing this task?
Or maybe you're using relative imports?

Please see
https://docs.celeryq.dev/en/latest/internals/protocol.html
for more information.

The full contents of the message body was:
b'[[], {}, {"callbacks": null, "errbacks": null, "chain": null, "chord": null}]' (77b)

The full contents of the message headers:
{'lang': 'py', 'task': 'tapir.accounts.tasks.send_create_account_reminder', 'id': '7d44cad6-dfd4-4d4c-b5b1-7dc4a7dea386', 'shadow': None, 'eta': None, 'expires': None, 'group': None, 'group_index': None, 'retries': 0, 'timelimit': [None, None], 'root_id': '7d44cad6-dfd4-4d4c-b5b1-7dc4a7dea386', 'parent_id': None, 'argsrepr': '()', 'kwargsrepr': '{}', 'origin': 'gen1@17e052a8e7b8', 'ignore_result': False, 'replaced_task_nesting': 0, 'stamped_headers': None, 'stamps': {}}

The delivery info for this task is:
{'exchange': '', 'routing_key': 'celery'}
Traceback (most recent call last):
  File "/root/.cache/pypoetry/virtualenvs/tapir-9TtSrW0h-py3.11/lib/python3.11/site-packages/celery/worker/consumer/consumer.py", line 658, in on_task_received
    strategy = strategies[type_]
               ~~~~~~~~~~^^^^^^^
KeyError: 'tapir.accounts.tasks.send_create_account_reminder'
```