### PR TITLE
Added a SlotModificationService to do shift deletion and updates in a controlled way.

### DIFF
--- a/tapir/shifts/management/commands/test_slot_modification_service.py
+++ b/tapir/shifts/management/commands/test_slot_modification_service.py
@@ -1,0 +1,27 @@
+import datetime
+
+from django.core.management.base import BaseCommand
+
+from tapir.shifts.models import ShiftUserCapability
+from tapir.shifts.services.slot_modification_service import SlotModificationService
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        changes = [
+            SlotModificationService.ParameterSet(
+                workday_or_weekend="workday",
+                time=datetime.time(hour=8, minute=15),
+                origin_slot_name=SlotModificationService.SlotNames.WARENANNAHME,
+                target_slot_name=None,
+                target_capabilities=None,
+            ),
+            SlotModificationService.ParameterSet(
+                workday_or_weekend="weekend",
+                time=datetime.time(hour=19, minute=15),
+                origin_slot_name=SlotModificationService.SlotNames.ALLGEMEIN,
+                target_slot_name=SlotModificationService.SlotNames.KASSE,
+                target_capabilities=frozenset([ShiftUserCapability.CASHIER]),
+            ),
+        ]
+        SlotModificationService.apply_changes(changes)

--- a/tapir/shifts/models.py
+++ b/tapir/shifts/models.py
@@ -143,7 +143,7 @@ class ShiftTemplateGroup(models.Model):
         return None
 
 
-# Generate weekdays
+# Generate weekdays, 0 is Monday, 6 is Sunday
 WEEKDAY_CHOICES = [
     (i, _(calendar.day_name[i])) for i in calendar.Calendar().iterweekdays()
 ]
@@ -341,6 +341,9 @@ class ShiftSlotTemplate(RequiredCapabilitiesMixin, models.Model):
         blank=True,
         null=False,
     )
+
+    def __str__(self):
+        return f"{self.name}, {self.shift_template}"
 
     def get_display_name(self):
         display_name = self.shift_template.get_display_name()

--- a/tapir/shifts/services/slot_modification_service.py
+++ b/tapir/shifts/services/slot_modification_service.py
@@ -105,7 +105,7 @@ class SlotModificationService:
             parameter_set, excluded_shift_template_ids
         )
         return [
-            cls.pick_slot_template_from_shift(parameter_set, shift_template)
+            cls.pick_slot_template_from_shift_template(parameter_set, shift_template)
             for shift_template in shift_templates
         ]
 
@@ -127,7 +127,7 @@ class SlotModificationService:
         return shift_templates.filter(weekend_shifts_filter)
 
     @classmethod
-    def pick_slot_template_from_shift(
+    def pick_slot_template_from_shift_template(
         cls, parameter_set: ParameterSet, shift_template: ShiftTemplate
     ) -> ShiftSlotTemplate:
         # The shift is assumed to have been picked according to the parameters, here we only look at the slot

--- a/tapir/shifts/services/slot_modification_service.py
+++ b/tapir/shifts/services/slot_modification_service.py
@@ -1,0 +1,194 @@
+import csv
+import datetime
+import io
+from dataclasses import dataclass
+from typing import List
+
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+
+from tapir.accounts.models import TapirUser
+from tapir.shifts.models import (
+    ShiftTemplate,
+    ShiftSlotTemplate,
+    ShiftAttendanceTemplate,
+    ShiftAttendance,
+    ShiftSlot,
+)
+from tapir.utils.user_utils import UserUtils
+
+
+class SlotModificationService:
+    @dataclass(frozen=True)
+    class ParameterSet:
+        workday_or_weekend: str
+        time: datetime.time
+        origin_slot_name: str
+        target_slot_name: str | None  # if None, the slot will be deleted
+        target_capabilities: frozenset | None
+
+    class SlotNames:
+        WARENANNAHME = "Warenannahme & Lager"
+        KASSE = "Kasse"
+        REINIGUNG = "Reinigung & Aufräumen"
+        ALLGEMEIN = ""
+
+    @classmethod
+    def build_changes(cls, parameter_sets: List[ParameterSet]):
+        return {
+            parameter_set: cls.pick_slots_to_modify(parameter_set)
+            for parameter_set in parameter_sets
+        }
+
+    @classmethod
+    def preview_changes(cls, parameter_sets: List[ParameterSet]):
+        changes = cls.build_changes(parameter_sets)
+        print(cls.get_affected_members(changes))
+
+    @classmethod
+    @transaction.atomic
+    def apply_changes(cls, parameter_sets: List[ParameterSet]):
+        changes = cls.build_changes(parameter_sets)
+        print(cls.get_affected_members(changes))
+
+        for parameter_set, slots_templates in changes.items():
+            for slot_template in slots_templates:
+                cls.apply_change(parameter_set, slot_template)
+
+    @classmethod
+    def apply_change(
+        cls, parameter_set: ParameterSet, slot_template: ShiftSlotTemplate
+    ):
+        if parameter_set.target_slot_name is None:
+            slot_template.generated_slots.all().delete()
+            slot_template.delete()
+            return
+
+        slot_template.generated_slots.update(name=parameter_set.target_slot_name)
+        slot_template.name = parameter_set.target_slot_name
+        slot_template.save()
+
+        if parameter_set.target_capabilities is None:
+            return
+
+        slot_template.generated_slots.update(
+            required_capabilities=list(parameter_set.target_capabilities)
+        )
+        slot_template.required_capabilities = list(parameter_set.target_capabilities)
+        slot_template.save()
+
+    @classmethod
+    def pick_slots_to_modify(cls, parameter_set: ParameterSet):
+        shift_templates = cls.pick_shift_templates(parameter_set)
+        return [
+            cls.pick_slot_template_from_shift(parameter_set, shift_template)
+            for shift_template in shift_templates
+        ]
+
+    @classmethod
+    def pick_shift_templates(cls, parameter_set: ParameterSet) -> List[ShiftTemplate]:
+        shift_templates = ShiftTemplate.objects.filter(start_time=parameter_set.time)
+        weekend_shifts_filter = Q(weekday__in=[5, 6])
+        if parameter_set.workday_or_weekend == "workday":
+            return shift_templates.exclude(weekend_shifts_filter)
+        return shift_templates.filter(weekend_shifts_filter)
+
+    @classmethod
+    def pick_slot_template_from_shift(
+        cls, parameter_set: ParameterSet, shift_template: ShiftTemplate
+    ) -> ShiftSlotTemplate:
+        # The shift is assumed to have been picked according to the parameters, here we only look at the slot
+
+        candidate_slot_templates = shift_template.slot_templates.filter(
+            name=parameter_set.origin_slot_name
+        )
+
+        if not candidate_slot_templates.exists():
+            raise ShiftSlotTemplate.DoesNotExist(
+                f"Could not find slot template with name {parameter_set.origin_slot_name} "
+                f"on shift template {parameter_set.origin_slot_name}"
+            )
+
+        if candidate_slot_templates.count() == 1:
+            return candidate_slot_templates.first()
+
+        # if possible, pick a slot that doesn't have an attendance
+        existing_attendance_templates = ShiftAttendanceTemplate.objects.filter(
+            slot_template__in=candidate_slot_templates
+        )
+        slot_templates_without_attendance = candidate_slot_templates.exclude(
+            attendance_template__in=existing_attendance_templates
+        )
+        if slot_templates_without_attendance.count() == 1:
+            return slot_templates_without_attendance.first()
+        if slot_templates_without_attendance.count() > 1:
+            candidate_slot_templates = slot_templates_without_attendance
+
+        return candidate_slot_templates.order_by("-id").first()
+
+    @classmethod
+    def get_affected_members(cls, changes: dict[ParameterSet, list[ShiftSlotTemplate]]):
+        result = io.StringIO()
+        writer = csv.writer(result)
+        writer.writerow(
+            ["member_id", "member_email", "member_name", "change", "slot", "warnings"]
+        )
+
+        for parameter_set, slot_templates in changes.items():
+            for slot_template in slot_templates:
+                already_written_user = None
+                if hasattr(slot_template, "attendance_template"):
+                    tapir_user = slot_template.attendance_template.user
+                    already_written_user = tapir_user
+                    cls.write_csv_row(writer, tapir_user, slot_template, parameter_set)
+                affected_attendances = ShiftAttendance.objects.filter(
+                    slot__in=slot_template.generated_slots.all(),
+                    slot__shift__start_time__gt=timezone.now(),
+                ).with_valid_state()
+                if already_written_user:
+                    affected_attendances = affected_attendances.exclude(
+                        user=already_written_user
+                    )
+                for attendance in affected_attendances:
+                    cls.write_csv_row(
+                        writer, attendance.user, attendance.slot, parameter_set
+                    )
+
+        return result.getvalue()
+
+    @classmethod
+    def write_csv_row(
+        cls,
+        writer,
+        tapir_user: TapirUser,
+        slot: ShiftSlotTemplate | ShiftSlot,
+        parameter_set: ParameterSet,
+    ):
+        prefix = "ABCD" if isinstance(slot, ShiftSlotTemplate) else "not-ABCD"
+
+        if parameter_set.target_slot_name is None:
+            change = f"{prefix} delete"
+        else:
+            change = (
+                f"{prefix} from {parameter_set.origin_slot_name} "
+                f"to {parameter_set.target_slot_name or 'Allgemein'}"
+            )
+
+        warning = "OK"
+        if parameter_set.target_capabilities is not None:
+            required_capabilities = parameter_set.target_capabilities
+            member_capabilities = set(tapir_user.shift_user_data.capabilities)
+            if not required_capabilities.issubset(member_capabilities):
+                warning = f"Missing qualifications: {list(required_capabilities.difference(member_capabilities))}"
+
+        writer.writerow(
+            [
+                tapir_user.get_member_number(),
+                tapir_user.email,
+                tapir_user.get_display_name(UserUtils.DISPLAY_NAME_TYPE_FULL),
+                change,
+                slot,
+                warning,
+            ]
+        )

--- a/tapir/shifts/tests/test_SlotModificationService.py
+++ b/tapir/shifts/tests/test_SlotModificationService.py
@@ -1,5 +1,15 @@
 import datetime
 
+from django.utils import timezone
+
+from tapir.accounts.tests.factories.factories import TapirUserFactory
+from tapir.shifts.models import (
+    ShiftTemplate,
+    ShiftSlotTemplate,
+    ShiftAttendanceTemplate,
+    ShiftSlot,
+    ShiftUserCapability,
+)
 from tapir.shifts.services.slot_modification_service import SlotModificationService
 from tapir.shifts.tests.factories import ShiftTemplateFactory
 from tapir.utils.tests_utils import TapirFactoryTestBase
@@ -8,10 +18,10 @@ from tapir.utils.tests_utils import TapirFactoryTestBase
 class TestSlotModificationService(TapirFactoryTestBase):
     def test_pickShiftTemplate_default_includesShiftsWithTheCorrectTime(self):
         targeted_time = datetime.time(hour=10, minute=45)
-        included_shift = ShiftTemplateFactory.create(
+        included_shift_template = ShiftTemplateFactory.create(
             start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=0
         )
-        excluded_shift = ShiftTemplateFactory.create(
+        excluded_shift_template = ShiftTemplateFactory.create(
             start_hour=10, start_minute=46, weekday=0
         )
         parameter_set = SlotModificationService.ParameterSet(
@@ -22,17 +32,17 @@ class TestSlotModificationService(TapirFactoryTestBase):
             target_capabilities=None,
         )
         selected_shifts = SlotModificationService.pick_shift_templates(parameter_set)
-        self.assertIn(included_shift, selected_shifts)
-        self.assertNotIn(excluded_shift, selected_shifts)
+        self.assertIn(included_shift_template, selected_shifts)
+        self.assertNotIn(excluded_shift_template, selected_shifts)
 
     def test_pickShiftTemplate_hasExcludedShiftParameter_doesNotIncludeExcludedShift(
         self,
     ):
         targeted_time = datetime.time(hour=10, minute=45)
-        included_shift = ShiftTemplateFactory.create(
+        included_shift_template = ShiftTemplateFactory.create(
             start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=0
         )
-        excluded_shift = ShiftTemplateFactory.create(
+        excluded_shift_template = ShiftTemplateFactory.create(
             start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=0
         )
         parameter_set = SlotModificationService.ParameterSet(
@@ -43,19 +53,19 @@ class TestSlotModificationService(TapirFactoryTestBase):
             target_capabilities=None,
         )
         selected_shifts = SlotModificationService.pick_shift_templates(
-            parameter_set, [excluded_shift.id]
+            parameter_set, [excluded_shift_template.id]
         )
-        self.assertIn(included_shift, selected_shifts)
-        self.assertNotIn(excluded_shift, selected_shifts)
+        self.assertIn(included_shift_template, selected_shifts)
+        self.assertNotIn(excluded_shift_template, selected_shifts)
 
     def test_pickShiftTemplate_workdayOnly_doesNotIncludeWeekendShift(
         self,
     ):
         targeted_time = datetime.time(hour=10, minute=45)
-        included_shift = ShiftTemplateFactory.create(
+        included_shift_template = ShiftTemplateFactory.create(
             start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=0
         )
-        excluded_shift = ShiftTemplateFactory.create(
+        excluded_shift_template = ShiftTemplateFactory.create(
             start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=5
         )
         parameter_set = SlotModificationService.ParameterSet(
@@ -66,19 +76,19 @@ class TestSlotModificationService(TapirFactoryTestBase):
             target_capabilities=None,
         )
         selected_shifts = SlotModificationService.pick_shift_templates(
-            parameter_set, [excluded_shift.id]
+            parameter_set, [excluded_shift_template.id]
         )
-        self.assertIn(included_shift, selected_shifts)
-        self.assertNotIn(excluded_shift, selected_shifts)
+        self.assertIn(included_shift_template, selected_shifts)
+        self.assertNotIn(excluded_shift_template, selected_shifts)
 
     def test_pickShiftTemplate_weekendOnly_doesNotIncludeWorkdayShift(
         self,
     ):
         targeted_time = datetime.time(hour=10, minute=45)
-        included_shift = ShiftTemplateFactory.create(
+        included_shift_template = ShiftTemplateFactory.create(
             start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=5
         )
-        excluded_shift = ShiftTemplateFactory.create(
+        excluded_shift_template = ShiftTemplateFactory.create(
             start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=0
         )
         parameter_set = SlotModificationService.ParameterSet(
@@ -89,7 +99,287 @@ class TestSlotModificationService(TapirFactoryTestBase):
             target_capabilities=None,
         )
         selected_shifts = SlotModificationService.pick_shift_templates(
-            parameter_set, [excluded_shift.id]
+            parameter_set, [excluded_shift_template.id]
         )
-        self.assertIn(included_shift, selected_shifts)
-        self.assertNotIn(excluded_shift, selected_shifts)
+        self.assertIn(included_shift_template, selected_shifts)
+        self.assertNotIn(excluded_shift_template, selected_shifts)
+
+    def test_pickSlotTemplateFromShift_default_returnsSlotWithCorrectName(self):
+        targeted_time = datetime.time(hour=10, minute=45)
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour,
+            start_minute=targeted_time.minute,
+            weekday=0,
+            nb_slots=2,
+        )
+
+        included_slot = shift_template.slot_templates.first()
+        excluded_slot = shift_template.slot_templates.last()
+
+        included_slot.name = "yes"
+        included_slot.save()
+        excluded_slot.name = "no"
+        excluded_slot.save()
+
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="yes",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name=None,
+            target_capabilities=None,
+        )
+
+        selected_slots = SlotModificationService.pick_slot_template_from_shift_template(
+            parameter_set, shift_template
+        )
+
+        self.assertEqual(included_slot, selected_slots)
+
+    def test_pickSlotTemplateFromShift_lookForSlotThatDoesntExist_raisesError(self):
+        targeted_time = datetime.time(hour=10, minute=45)
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour,
+            start_minute=targeted_time.minute,
+            weekday=0,
+            nb_slots=2,
+        )
+
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="does_not_exist",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name=None,
+            target_capabilities=None,
+        )
+
+        with self.assertRaises(ShiftSlotTemplate.DoesNotExist):
+            SlotModificationService.pick_slot_template_from_shift_template(
+                parameter_set, shift_template
+            )
+
+    def test_pickSlotTemplateFromShift_onlyOneSlotWithName_returnsTheSlotEvenIfItIsOccupied(
+        self,
+    ):
+        targeted_time = datetime.time(hour=10, minute=45)
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour,
+            start_minute=targeted_time.minute,
+            weekday=0,
+            nb_slots=1,
+        )
+        slot_template = shift_template.slot_templates.get()
+        ShiftAttendanceTemplate.objects.create(
+            user=TapirUserFactory.create(),
+            slot_template=slot_template,
+        )
+
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name=slot_template.name,
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name=None,
+            target_capabilities=None,
+        )
+
+        self.assertEqual(
+            slot_template,
+            SlotModificationService.pick_slot_template_from_shift_template(
+                parameter_set, shift_template
+            ),
+        )
+
+    def test_pickSlotTemplateFromShift_someSlotsOccupied_returnsANotOccupiedSlot(
+        self,
+    ):
+        targeted_time = datetime.time(hour=10, minute=45)
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour,
+            start_minute=targeted_time.minute,
+            weekday=0,
+            nb_slots=3,
+        )
+
+        unoccupied_slot = None
+        for index, slot_template in enumerate(shift_template.slot_templates.all()):
+            slot_template.name = "yes"
+            slot_template.save()
+
+            if index == 1:
+                unoccupied_slot = slot_template
+                continue
+
+            ShiftAttendanceTemplate.objects.create(
+                user=TapirUserFactory.create(),
+                slot_template=slot_template,
+            )
+
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="yes",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name=None,
+            target_capabilities=None,
+        )
+
+        self.assertEqual(
+            unoccupied_slot,
+            SlotModificationService.pick_slot_template_from_shift_template(
+                parameter_set, shift_template
+            ),
+        )
+
+    def test_pickSlotTemplateFromShift_allSlotsOccupied_returnsAnOccupiedSlot(
+        self,
+    ):
+        targeted_time = datetime.time(hour=10, minute=45)
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour,
+            start_minute=targeted_time.minute,
+            weekday=0,
+            nb_slots=3,
+        )
+
+        shift_template.slot_templates.update(name="yes")
+        for index, slot_template in enumerate(shift_template.slot_templates.all()):
+            ShiftAttendanceTemplate.objects.create(
+                user=TapirUserFactory.create(),
+                slot_template=slot_template,
+            )
+
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="yes",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name=None,
+            target_capabilities=None,
+        )
+
+        self.assertIn(
+            SlotModificationService.pick_slot_template_from_shift_template(
+                parameter_set, shift_template
+            ),
+            shift_template.slot_templates.all(),
+        )
+
+    def test_applyChange_targetNameIsNone_slotTemplateAndGeneratedSlotsGetDeleted(self):
+        targeted_time = datetime.time(hour=10, minute=45)
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create()
+        shift_template.create_shift(timezone.now().date())
+        slot_template_to_delete = shift_template.slot_templates.get()
+
+        self.assertEqual(1, ShiftSlot.objects.count())
+        self.assertEqual(1, ShiftSlotTemplate.objects.count())
+
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name=None,
+            target_capabilities=None,
+        )
+
+        SlotModificationService.apply_change(parameter_set, slot_template_to_delete)
+
+        self.assertFalse(ShiftSlot.objects.exists())
+        self.assertFalse(ShiftSlotTemplate.objects.exists())
+
+    def test_applyChange_targetNameIsSet_slotTemplateAndGeneratedSlotsGetRenamed(self):
+        targeted_time = datetime.time(hour=10, minute=45)
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create()
+        shift_template.create_shift(timezone.now().date())
+        slot_template_to_rename = shift_template.slot_templates.get()
+
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name="new_name",
+            target_capabilities=None,
+        )
+
+        SlotModificationService.apply_change(parameter_set, slot_template_to_rename)
+
+        self.assertEqual("new_name", ShiftSlot.objects.get().name)
+        self.assertEqual("new_name", ShiftSlotTemplate.objects.get().name)
+
+    def test_applyChange_targetCapabilitiesIsNone_capabilitiesNotAffected(self):
+        targeted_time = datetime.time(hour=10, minute=45)
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create()
+        shift_template.create_shift(timezone.now().date())
+        slot_template = shift_template.slot_templates.get()
+
+        capabilities = [ShiftUserCapability.CASHIER]
+        slot_template.required_capabilities = capabilities
+        slot_template.save()
+        slot_template.generated_slots.update(required_capabilities=capabilities)
+
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name="new_name",
+            target_capabilities=None,
+        )
+
+        SlotModificationService.apply_change(parameter_set, slot_template)
+
+        self.assertEqual(capabilities, ShiftSlot.objects.get().required_capabilities)
+        self.assertEqual(
+            capabilities, ShiftSlotTemplate.objects.get().required_capabilities
+        )
+
+    def test_applyChange_targetCapabilitiesIsEmpty_capabilitiesNotRequiredAnymore(self):
+        targeted_time = datetime.time(hour=10, minute=45)
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create()
+        shift_template.create_shift(timezone.now().date())
+        slot_template = shift_template.slot_templates.get()
+
+        capabilities = [ShiftUserCapability.CASHIER]
+        slot_template.required_capabilities = capabilities
+        slot_template.save()
+        slot_template.generated_slots.update(required_capabilities=capabilities)
+
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name="new_name",
+            target_capabilities=frozenset([]),
+        )
+
+        SlotModificationService.apply_change(parameter_set, slot_template)
+
+        self.assertEqual([], ShiftSlot.objects.get().required_capabilities)
+        self.assertEqual([], ShiftSlotTemplate.objects.get().required_capabilities)
+
+    def test_applyChange_targetCapabilitiesIsNotEmpty_capabilitiesUpdated(self):
+        targeted_time = datetime.time(hour=10, minute=45)
+        shift_template: ShiftTemplate = ShiftTemplateFactory.create()
+        shift_template.create_shift(timezone.now().date())
+        slot_template = shift_template.slot_templates.get()
+
+        capabilities_before = [ShiftUserCapability.CASHIER]
+        slot_template.required_capabilities = capabilities_before
+        slot_template.save()
+        slot_template.generated_slots.update(required_capabilities=capabilities_before)
+
+        capabilities_after = [
+            ShiftUserCapability.RED_CARD,
+            ShiftUserCapability.MEMBER_OFFICE,
+        ]
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name="new_name",
+            target_capabilities=frozenset(capabilities_after),
+        )
+
+        SlotModificationService.apply_change(parameter_set, slot_template)
+
+        self.assertEqual(
+            capabilities_after, ShiftSlot.objects.get().required_capabilities
+        )
+        self.assertEqual(
+            capabilities_after, ShiftSlotTemplate.objects.get().required_capabilities
+        )

--- a/tapir/shifts/tests/test_SlotModificationService.py
+++ b/tapir/shifts/tests/test_SlotModificationService.py
@@ -35,7 +35,7 @@ class TestSlotModificationService(TapirFactoryTestBase):
         self.assertIn(included_shift_template, selected_shifts)
         self.assertNotIn(excluded_shift_template, selected_shifts)
 
-    def test_pickShiftTemplate_hasExcludedShiftParameter_doesNotIncludeExcludedShift(
+    def test_pickShiftTemplate_hasExcludedShiftId_doesNotIncludeExcludedShift(
         self,
     ):
         targeted_time = datetime.time(hour=10, minute=45)

--- a/tapir/shifts/tests/test_SlotModificationService.py
+++ b/tapir/shifts/tests/test_SlotModificationService.py
@@ -1,0 +1,95 @@
+import datetime
+
+from tapir.shifts.services.slot_modification_service import SlotModificationService
+from tapir.shifts.tests.factories import ShiftTemplateFactory
+from tapir.utils.tests_utils import TapirFactoryTestBase
+
+
+class TestSlotModificationService(TapirFactoryTestBase):
+    def test_pickShiftTemplate_default_includesShiftsWithTheCorrectTime(self):
+        targeted_time = datetime.time(hour=10, minute=45)
+        included_shift = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=0
+        )
+        excluded_shift = ShiftTemplateFactory.create(
+            start_hour=10, start_minute=46, weekday=0
+        )
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name=None,
+            target_capabilities=None,
+        )
+        selected_shifts = SlotModificationService.pick_shift_templates(parameter_set)
+        self.assertIn(included_shift, selected_shifts)
+        self.assertNotIn(excluded_shift, selected_shifts)
+
+    def test_pickShiftTemplate_hasExcludedShiftParameter_doesNotIncludeExcludedShift(
+        self,
+    ):
+        targeted_time = datetime.time(hour=10, minute=45)
+        included_shift = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=0
+        )
+        excluded_shift = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=0
+        )
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name=None,
+            target_capabilities=None,
+        )
+        selected_shifts = SlotModificationService.pick_shift_templates(
+            parameter_set, [excluded_shift.id]
+        )
+        self.assertIn(included_shift, selected_shifts)
+        self.assertNotIn(excluded_shift, selected_shifts)
+
+    def test_pickShiftTemplate_workdayOnly_doesNotIncludeWeekendShift(
+        self,
+    ):
+        targeted_time = datetime.time(hour=10, minute=45)
+        included_shift = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=0
+        )
+        excluded_shift = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=5
+        )
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="",
+            workday_or_weekend=SlotModificationService.WORKDAY,
+            time=targeted_time,
+            target_slot_name=None,
+            target_capabilities=None,
+        )
+        selected_shifts = SlotModificationService.pick_shift_templates(
+            parameter_set, [excluded_shift.id]
+        )
+        self.assertIn(included_shift, selected_shifts)
+        self.assertNotIn(excluded_shift, selected_shifts)
+
+    def test_pickShiftTemplate_weekendOnly_doesNotIncludeWorkdayShift(
+        self,
+    ):
+        targeted_time = datetime.time(hour=10, minute=45)
+        included_shift = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=5
+        )
+        excluded_shift = ShiftTemplateFactory.create(
+            start_hour=targeted_time.hour, start_minute=targeted_time.minute, weekday=0
+        )
+        parameter_set = SlotModificationService.ParameterSet(
+            origin_slot_name="",
+            workday_or_weekend=SlotModificationService.WEEKEND,
+            time=targeted_time,
+            target_slot_name=None,
+            target_capabilities=None,
+        )
+        selected_shifts = SlotModificationService.pick_shift_templates(
+            parameter_set, [excluded_shift.id]
+        )
+        self.assertIn(included_shift, selected_shifts)
+        self.assertNotIn(excluded_shift, selected_shifts)

--- a/tapir/shifts/tests/test_SlotModificationService.py
+++ b/tapir/shifts/tests/test_SlotModificationService.py
@@ -378,8 +378,9 @@ class TestSlotModificationService(TapirFactoryTestBase):
         SlotModificationService.apply_change(parameter_set, slot_template)
 
         self.assertEqual(
-            capabilities_after, ShiftSlot.objects.get().required_capabilities
+            set(capabilities_after), set(ShiftSlot.objects.get().required_capabilities)
         )
         self.assertEqual(
-            capabilities_after, ShiftSlotTemplate.objects.get().required_capabilities
+            set(capabilities_after),
+            set(ShiftSlotTemplate.objects.get().required_capabilities),
         )


### PR DESCRIPTION
Since we want to many slots now and later make slot deletion available for Vorstand members, I made a little service that searches for the most appropriate slots to update (the ones without a member registered to them if available) and prints out which members are affected by the changes so that they can be contacted if necessary. 

I added a management command so that it's easy to test, [edit the command](https://github.com/SuperCoopBerlin/tapir/blob/430a79b9e8fbbf52824c11a3c6c58fdd09245329/tapir/shifts/management/commands/test_slot_modification_service.py) then run:
```sh
docker compose exec web poetry run python manage.py test_slot_modification_service
```

I'm hoping it could be used as a base or as a reference if we make slot deletion available for Vorstand members.

I'm fairly confident that it works as intended, but it'd be great to have some feedback on how readable it is. Thanks!