### PR TITLE
Update .pre-commit-config.yaml: Ignore migrations with black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: 22.10.0
     hooks:
       - id: black
+        exclude: ^.*\b(migrations)\b.*$
   - repo: https://github.com/Riverside-Healthcare/djLint
     rev: v1.34.1
     hooks:


### PR DESCRIPTION
Since migrations are auto-generated, we could ignore them. My PyCharm feels stubborn if I don't