### PR TITLE
Final fixes on resignation-issue

### DIFF
--- a/tapir/coop/forms.py
+++ b/tapir/coop/forms.py
@@ -311,9 +311,6 @@ class MembershipResignationForm(forms.ModelForm):
             )
 
     def validate_transfer_choice(self, resignation_type, transferring_shares_to):
-
-        print(f"trans {transferring_shares_to}")
-
         if (
             resignation_type == MembershipResignation.ResignationType.TRANSFER
             and transferring_shares_to is None
@@ -341,7 +338,6 @@ class MembershipResignationForm(forms.ModelForm):
             )
 
     def validate_duplicates(self, share_owner, transferring_shares_to):
-        print(transferring_shares_to, share_owner)
         if transferring_shares_to == share_owner:
             self.add_error(
                 "transferring_shares_to",

--- a/tapir/coop/forms.py
+++ b/tapir/coop/forms.py
@@ -280,13 +280,16 @@ class MembershipResignationForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
+        share_owner: ShareOwner = cleaned_data.get("share_owner")
         resignation_type = cleaned_data.get("resignation_type")
         cancellation_date = cleaned_data.get("cancellation_date")
+        transferring_shares_to = cleaned_data.get("transferring_shares_to")
+        paid_out = cleaned_data.get("paid_out")
 
-        self.validate_share_owner()
-        self.validate_transfer_choice()
-        self.validate_duplicates()
-        self.validate_if_gifted()
+        self.validate_share_owner(share_owner)
+        self.validate_transfer_choice(resignation_type, transferring_shares_to)
+        self.validate_duplicates(share_owner, transferring_shares_to)
+        self.validate_if_gifted(resignation_type, paid_out)
 
         if resignation_type == MembershipResignation.ResignationType.BUY_BACK:
             self.cleaned_data["pay_out_day"] = cancellation_date + relativedelta(
@@ -298,11 +301,7 @@ class MembershipResignationForm(forms.ModelForm):
 
         return cleaned_data
 
-    def validate_share_owner(self):
-        share_owner: ShareOwner = self.cleaned_data.get("share_owner")
-        if self.instance.pk is not None:
-            return share_owner
-
+    def validate_share_owner(self, share_owner):
         if MembershipResignation.objects.filter(
             share_owner__id=share_owner.id
         ).exists():
@@ -311,9 +310,9 @@ class MembershipResignationForm(forms.ModelForm):
                 ValidationError(_("This member is already resigned.")),
             )
 
-    def validate_transfer_choice(self):
-        resignation_type = self.cleaned_data.get("resignation_type")
-        transferring_shares_to = self.cleaned_data.get("transferring_shares_to")
+    def validate_transfer_choice(self, resignation_type, transferring_shares_to):
+
+        print(f"trans {transferring_shares_to}")
 
         if (
             resignation_type == MembershipResignation.ResignationType.TRANSFER
@@ -341,9 +340,8 @@ class MembershipResignationForm(forms.ModelForm):
                 ),
             )
 
-    def validate_duplicates(self):
-        transferring_shares_to = self.cleaned_data.get("transferring_shares_to")
-        share_owner = self.cleaned_data.get("share_owner")
+    def validate_duplicates(self, share_owner, transferring_shares_to):
+        print(transferring_shares_to, share_owner)
         if transferring_shares_to == share_owner:
             self.add_error(
                 "transferring_shares_to",
@@ -354,10 +352,7 @@ class MembershipResignationForm(forms.ModelForm):
                 ),
             )
 
-    def validate_if_gifted(self):
-        resignation_type = self.cleaned_data.get("resignation_type")
-        paid_out = self.cleaned_data.get("paid_out")
-
+    def validate_if_gifted(self, resignation_type, paid_out):
         if paid_out and (
             resignation_type
             in [

--- a/tapir/coop/services/MembershipResignationService.py
+++ b/tapir/coop/services/MembershipResignationService.py
@@ -23,6 +23,8 @@ class MembershipResignationService:
             case MembershipResignation.ResignationType.BUY_BACK:
                 new_end_date = resignation.cancellation_date.replace(day=31, month=12)
                 new_end_date = new_end_date.replace(year=new_end_date.year + 3)
+                resignation.pay_out_day = new_end_date
+                resignation.save()
                 shares.update(end_date=new_end_date)
                 return
             case MembershipResignation.ResignationType.GIFT_TO_COOP:

--- a/tapir/coop/templates/coop/member_management.html
+++ b/tapir/coop/templates/coop/member_management.html
@@ -4,7 +4,7 @@
 {% load static %}
 {% load core %}
 {% block title %}
-    {% translate "Shift management" %}
+    {% translate "Member management" %}
 {% endblock title %}
 {% block head %}
     {{ block.super }}

--- a/tapir/coop/templates/coop/membershipresignation_detail.html
+++ b/tapir/coop/templates/coop/membershipresignation_detail.html
@@ -57,6 +57,13 @@
                     <div class="col-9"
                          id="membership_resignation_cancellation_date">{{ object.cancellation_date|date:"d.m.Y" }}</div>
                 </div>
+                {% if object.pay_out_day is not None %}
+                <div class="row m-1">
+                    <div class="col-3 fw-bold text-end">{% translate "Membership ends" %}:</div>
+                    <div class="col-9"
+                         id="membership_resignation_cancellation_date">{{ object.pay_out_day|date:"d.m.Y" }}</div>
+                </div>
+                {% endif %}
                 <div class="row m-1">
                     <div class="col-3 fw-bold text-end">{% translate "Resignation type" %}:</div>
                     <div class="col-9" id="resignation_type">

--- a/tapir/coop/views/membership_resignation.py
+++ b/tapir/coop/views/membership_resignation.py
@@ -58,9 +58,7 @@ class MembershipResignationTable(django_tables2.Table):
             "paid_out",
             "add_buttons",
         ]
-        exclude = [
-            "resignation_type"
-        ]
+        exclude = ["resignation_type"]
         order_by = "-cancellation_date"
         attrs = {"class": TAPIR_TABLE_CLASSES}
         empty_text = "No entries"

--- a/tapir/coop/views/membership_resignation.py
+++ b/tapir/coop/views/membership_resignation.py
@@ -52,12 +52,14 @@ class MembershipResignationTable(django_tables2.Table):
         ]
         sequence = [
             "share_owner",
-            "resignation_type",
             "cancellation_reason",
             "cancellation_date",
             "pay_out_day",
             "paid_out",
             "add_buttons",
+        ]
+        exclude = [
+            "resignation_type"
         ]
         order_by = "-cancellation_date"
         attrs = {"class": TAPIR_TABLE_CLASSES}


### PR DESCRIPTION
Hi @Theophile-Madet here the new fixes on the final stage of the resignment process. I've change the parameters in the functions of the form-cleaning , 'cause calling the cleaned_data function in several places didn't work and just produced None. I've checked the hole UI on my local and it seems to work probably so far. Only thing which is not implemented yet, what I noticed, is if someone changes the transferring_shares_to-member after it has been set for the first time. If this is done, then no shares will be transferred to the new member and no shares will removed from the old one. Maybe we should implement that if the transferring_shares_to-member is set once to disable the field in the form for the future? What di you think? 