### PR TITLE
Printing shifts now ordered and with more margin

### DIFF
--- a/tapir/shifts/templates/shifts/shift_day_printable.html
+++ b/tapir/shifts/templates/shifts/shift_day_printable.html
@@ -3,7 +3,7 @@
 <style>
     @page {
         size: A4 portrait;
-        margin: 0;
+        margin: 20;
     }
 
     @media print {

--- a/tapir/shifts/views/views.py
+++ b/tapir/shifts/views/views.py
@@ -241,7 +241,9 @@ class ShiftDayPrintableView(LoginRequiredMixin, PermissionRequiredMixin, Templat
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
         day = datetime.datetime.strptime(kwargs["day"], "%d-%m-%y").date()
-        context["shifts"] = Shift.objects.filter(start_time__date=day)
+        context["shifts"] = Shift.objects.filter(start_time__date=day).order_by(
+            "start_time"
+        )
         return context
 
 


### PR DESCRIPTION
Salut @Theophile-Madet , j'ai parler la semaine dernière avec Jonathan à la coop. Et il m'a montré les listes des shifts imprimée et que c'est un peu confus pour le team à place que les shifts ne sont pas toujours en ordre. Sûrement parce que si quelqu'un ajoute une shift additionnelle l'ordre est rétablit sur l'UI du shift-calendar, mais pas pour l'UI de shift_day_printable.html. Alors j'ai ajouté .order_by("start_time") à ShiftDayPrintableView, comme tu l'as fait dans ShiftCalendarView en ligne 65. Et aussi j'ai élevé la valeur du margin dans shift_day_printable.html, car il m'a dit que se sont toujours différents personnes, qui impriment les plans des shifts et comme ça ils ne sont pas toujours en courant concernant  une façon d'imprimer adéquate pour une meilleure lisibilité. Si tu est d'accord avec se PR, pourrais-tu le deployer rapidement sur prod1-server? Ca aidera sûrement le membres sur place et aussi l'office des membres dans leur travail quotidien. J'espère que tu peux suivre mon raisonnement? Merci et beaucoup de saluts, Kersten