### PR TITLE
Collapsing also for the log view

### DIFF
--- a/tapir/log/templates/log/log_overview.html
+++ b/tapir/log/templates/log/log_overview.html
@@ -34,21 +34,17 @@
                 </div>
             </div>
         </div>
-        <div class="collapse" id="collapseFilter">
-            <ul class="list-group list-group-flush">
-                <li class="list-group-item">
-                    {% if filter %}
-                        <form action="" method="get" class="form log-filter-form">
-                            {% bootstrap_form filter.form %}
-                            <button class="filter-button {% tapir_button_link %}">
-                                <span class="material-icons">filter_alt</span>{% translate 'Filter' %}
-                            </button>
-                        </form>
-                    {% endif %}
-                </li>
-            </ul>
-        </div>
         <ul class="list-group list-group-flush">
+            <li class="list-group-item collapse" id="collapseFilter">
+                {% if filter %}
+                    <form action="" method="get" class="form log-filter-form">
+                        {% bootstrap_form filter.form %}
+                        <button class="filter-button {% tapir_button_link %}">
+                            <span class="material-icons">filter_alt</span>{% translate 'Filter' %}
+                        </button>
+                    </form>
+                {% endif %}
+            </li>
             <li class="list-group-item">{% render_table table %}</li>
         </ul>
     </div>

--- a/tapir/log/templates/log/log_overview.html
+++ b/tapir/log/templates/log/log_overview.html
@@ -12,20 +12,43 @@
 {% endblock head %}
 {% block content %}
     <div class="card m-2">
-        <h5 class="card-header d-flex justify-content-between">
-            <span>{% translate "Logs" %}</span>
-        </h5>
-        <ul class="list-group list-group-flush">
-            <li class="list-group-item">
-                {% if filter %}
-                    <form action="" method="get" class="form log-filter-form">
-                        {% bootstrap_form filter.form %}
-                        <button class="filter-button {% tapir_button_link %}">
-                            <span class="material-icons">filter_alt</span>{% translate 'Filter' %}
+        <div class="card-header d-flex justify-content-between">
+            <div class="container-fluid">
+                <div class="row">
+                    <div class="col-6">
+                        <h5>
+                            <span>{% translate "Logs" %}</span>
+                        </h5>
+                    </div>
+                    <div class="col-6 d-flex justify-content-end">
+                        <button class="{% tapir_button_link_to_action %}"
+                                type="button"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#collapseFilter"
+                                aria-expanded="false"
+                                aria-controls="collapseFilter">
+                            {% translate "Filters" %}
+                            <span class="material-icons">unfold_more</span>
                         </button>
-                    </form>
-                {% endif %}
-            </li>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="collapse" id="collapseFilter">
+            <ul class="list-group list-group-flush">
+                <li class="list-group-item">
+                    {% if filter %}
+                        <form action="" method="get" class="form log-filter-form">
+                            {% bootstrap_form filter.form %}
+                            <button class="filter-button {% tapir_button_link %}">
+                                <span class="material-icons">filter_alt</span>{% translate 'Filter' %}
+                            </button>
+                        </form>
+                    {% endif %}
+                </li>
+            </ul>
+        </div>
+        <ul class="list-group list-group-flush">
             <li class="list-group-item">{% render_table table %}</li>
         </ul>
     </div>

--- a/tapir/log/templates/log/log_overview.html
+++ b/tapir/log/templates/log/log_overview.html
@@ -8,6 +8,11 @@
 {% block head %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static "coop/css/coop.css" %}">
+    <style>
+        .select2 {    
+            width: 100%!important; /* overrides computed width, 100px in your demo */ 
+        }
+    </style>
     {{ filter.form.media }}
 {% endblock head %}
 {% block content %}

--- a/tapir/log/templates/log/log_overview.html
+++ b/tapir/log/templates/log/log_overview.html
@@ -17,25 +17,23 @@
 {% endblock head %}
 {% block content %}
     <div class="card m-2">
-        <div class="card-header d-flex justify-content-between">
-            <div class="container-fluid">
-                <div class="row">
-                    <div class="col-6">
-                        <h5>
-                            <span>{% translate "Logs" %}</span>
-                        </h5>
-                    </div>
-                    <div class="col-6 d-flex justify-content-end">
-                        <button class="{% tapir_button_link_to_action %}"
-                                type="button"
-                                data-bs-toggle="collapse"
-                                data-bs-target="#collapseFilter"
-                                aria-expanded="false"
-                                aria-controls="collapseFilter">
-                            {% translate "Filters" %}
-                            <span class="material-icons">unfold_more</span>
-                        </button>
-                    </div>
+        <div class="card-header">
+            <div class="d-flex flex-row justify-content-between">
+                <div class="col-6 d-flex flex-column justify-content-center">
+                    <h5 style="margin-bottom: 0">
+                        <span>{% translate "Logs" %}</span>
+                    </h5>
+                </div>
+                <div class="col-6 d-flex justify-content-end">
+                    <button class="{% tapir_button_link_to_action %}"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapseFilter"
+                            aria-expanded="false"
+                            aria-controls="collapseFilter">
+                        {% translate "Filters" %}
+                        <span class="material-icons">unfold_more</span>
+                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
I thought also for the log view it would not be bad to collapse the filters. Hope you too ? Only bug here at my local are the 2 shorten form elements "Actor" and "Member". Are they also shorten at your machine? Don't get a clue. When disabling the collapsing then both are in full length of the screen. Maybe you have an idea what's wrong?

<img width="1280" alt="Bildschirmfoto 2024-09-29 um 19 55 47" src="https://github.com/user-attachments/assets/960d6b54-7050-410f-ac1a-12454a5c8285">
