### PR TITLE
Little resignation improvements - deleting end_dates

### DIFF
--- a/tapir/coop/services/membership_resignation_service.py
+++ b/tapir/coop/services/membership_resignation_service.py
@@ -97,10 +97,9 @@ class MembershipResignationService:
 
     @staticmethod
     def delete_end_dates(resignation: MembershipResignation):
-        for share_ownership in resignation.share_owner.share_ownerships.all():
-            if share_ownership.end_date >= resignation.cancellation_date:
-                share_ownership.end_date = None
-                share_ownership.save()
+        resignation.share_owner.share_ownerships.filter(
+            end_date__gte=resignation.cancellation_date
+        ).update(end_date=None)
 
     @classmethod
     def delete_transferred_share_ownerships(cls, resignation: MembershipResignation):

--- a/tapir/coop/services/membership_resignation_service.py
+++ b/tapir/coop/services/membership_resignation_service.py
@@ -97,15 +97,13 @@ class MembershipResignationService:
 
     @staticmethod
     def delete_end_dates(resignation: MembershipResignation):
-        resignation.share_owner.share_ownerships.filter(
-            end_date=resignation.cancellation_date
-        ).update(end_date=None)
+        resignation.share_owner.share_ownerships.update(end_date=None)
 
     @classmethod
     def delete_transferred_share_ownerships(cls, resignation: MembershipResignation):
         if (
-            not resignation.resignation_type
-            == MembershipResignation.ResignationType.TRANSFER
+            resignation.resignation_type
+            != MembershipResignation.ResignationType.TRANSFER
         ):
             return
         ended_ownerships = resignation.share_owner.share_ownerships.filter(

--- a/tapir/coop/services/membership_resignation_service.py
+++ b/tapir/coop/services/membership_resignation_service.py
@@ -97,7 +97,10 @@ class MembershipResignationService:
 
     @staticmethod
     def delete_end_dates(resignation: MembershipResignation):
-        resignation.share_owner.share_ownerships.update(end_date=None)
+        for share_ownership in resignation.share_owner.share_ownerships.all():
+            if share_ownership.end_date >= resignation.cancellation_date:
+                share_ownership.end_date = None
+                share_ownership.save()
 
     @classmethod
     def delete_transferred_share_ownerships(cls, resignation: MembershipResignation):

--- a/tapir/coop/tests/membership_resignation/test_delete_view.py
+++ b/tapir/coop/tests/membership_resignation/test_delete_view.py
@@ -69,6 +69,7 @@ class TestMembershipResignationDeleteView(
 
         self.assertStatusCode(response, HTTPStatus.OK)
         mock_on_resignation_deleted.assert_called_once_with(resignation)
+        self.assertTrue(resignation.share_owner.share_ownerships.first().end_date, None)
 
     def test_membershipResignationDeleteView_default_logEntryCreated(self):
         actor = self.login_as_vorstand()

--- a/tapir/coop/tests/membership_resignation/test_delete_view.py
+++ b/tapir/coop/tests/membership_resignation/test_delete_view.py
@@ -69,7 +69,6 @@ class TestMembershipResignationDeleteView(
 
         self.assertStatusCode(response, HTTPStatus.OK)
         mock_on_resignation_deleted.assert_called_once_with(resignation)
-        self.assertTrue(resignation.share_owner.share_ownerships.first().end_date, None)
 
     def test_membershipResignationDeleteView_default_logEntryCreated(self):
         actor = self.login_as_vorstand()


### PR DESCRIPTION
Hi @Theophile-Madet, while checking out further your implementations for the resignation issue, I fall over (what seems to me) a little bug, after I tried to cancel and remove a resigned member from the list (with 3 years cash back) here on my local. With the former filtering in the `delete_end_dates` function checking whether the cancellation_date equals the end_date, so the end_dates of peoples with shares ending 3 years in the future don't get set to None. Hope this PR makes sense to you?!