### PR TITLE
Fix transferred shares not being deleted when deleting a resignation of type transfer.

### DIFF
--- a/tapir/coop/services/membership_resignation_service.py
+++ b/tapir/coop/services/membership_resignation_service.py
@@ -92,8 +92,8 @@ class MembershipResignationService:
 
     @classmethod
     def on_resignation_deleted(cls, resignation: MembershipResignation):
-        cls.delete_end_dates(resignation)
         cls.delete_transferred_share_ownerships(resignation)
+        cls.delete_end_dates(resignation)
 
     @staticmethod
     def delete_end_dates(resignation: MembershipResignation):

--- a/tapir/coop/tests/membership_resignation/test_delete_view.py
+++ b/tapir/coop/tests/membership_resignation/test_delete_view.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 from unittest.mock import patch, Mock
 
 from django.urls import reverse
+from django.utils import timezone
 
 from tapir import settings
 from tapir.coop.config import feature_flag_membership_resignation
@@ -15,6 +16,7 @@ from tapir.coop.services.membership_resignation_service import (
 )
 from tapir.coop.tests.factories import (
     MembershipResignationFactory,
+    ShareOwnerFactory,
 )
 from tapir.utils.tests_utils import (
     FeatureFlagTestMixin,
@@ -83,3 +85,36 @@ class TestMembershipResignationDeleteView(
         log_entry = MembershipResignationDeleteLogEntry.objects.get()
         self.assertEqual(resignation.id, int(log_entry.values["id"]))
         self.assertEqual(actor, log_entry.actor)
+
+    def test_membershipResignationDeleteView_sharesWereTransferred_updateTransferredShares(
+        self,
+    ):
+        actor = self.login_as_vorstand()
+        member_that_gifts_shares = ShareOwnerFactory.create(nb_shares=3)
+        member_that_receives_shares = ShareOwnerFactory.create(nb_shares=1)
+
+        data = {
+            "share_owner": member_that_gifts_shares.id,
+            "cancellation_reason": "Test resignation",
+            "cancellation_reason_category": MembershipResignation.CancellationReasons.OTHER,
+            "cancellation_date": timezone.now().date(),
+            "resignation_type": MembershipResignation.ResignationType.TRANSFER,
+            "transferring_shares_to": member_that_receives_shares.id,
+        }
+
+        response = self.client.post(
+            reverse("coop:membership_resignation_create"),
+            data=data,
+            follow=True,
+        )
+        self.assertStatusCode(response, HTTPStatus.OK)
+        resignation = MembershipResignation.objects.get()
+
+        response = self.client.post(
+            reverse("coop:membership_resignation_delete", args=[resignation.id]),
+            follow=True,
+        )
+        self.assertStatusCode(response, HTTPStatus.OK)
+
+        self.assertEqual(1, member_that_receives_shares.share_ownerships.count())
+        self.assertEqual(3, member_that_gifts_shares.share_ownerships.count())


### PR DESCRIPTION
Fix delete_transferred_share_ownerships not working: it was called after delete_end_dates, which made it useless.