### PR TITLE
Fixed start date of shares created from a resignation of type transfer.

### DIFF
--- a/tapir/coop/services/membership_resignation_service.py
+++ b/tapir/coop/services/membership_resignation_service.py
@@ -42,7 +42,8 @@ class MembershipResignationService:
                 shares_to_create = [
                     ShareOwnership(
                         share_owner=resignation.transferring_shares_to,
-                        start_date=resignation.cancellation_date,
+                        start_date=resignation.cancellation_date
+                        + datetime.timedelta(days=1),
                         transferred_from=share,
                     )
                     for share in shares

--- a/tapir/coop/tests/membership_resignation/test_service.py
+++ b/tapir/coop/tests/membership_resignation/test_service.py
@@ -112,7 +112,7 @@ class TestMembershipResignationService(FeatureFlagTestMixin, TapirFactoryTestBas
                 self.assertIsNone(share.transferred_from)
                 continue
             self.assertEqual(None, share.end_date)
-            self.assertEqual(self.TODAY, share.start_date)
+            self.assertEqual(self.TODAY + datetime.timedelta(days=1), share.start_date)
             self.assertIn(share.transferred_from, gifting_member.share_ownerships.all())
             shares_of_gifting_member.remove(
                 share.transferred_from


### PR DESCRIPTION
When creating a resignation of type transfer, the shares of the receiving member were created with the start date = the end date of the shares of the gifting member.

This would mean that on the resignation day, there are two shares active for each transferred share. The created shares should start a day after.