### PR TITLE
Changed celery-time to 3am for purchase and credit

### DIFF
--- a/tapir/settings.py
+++ b/tapir/settings.py
@@ -153,11 +153,11 @@ CELERY_BEAT_SCHEDULE = {
     },
     "process_purchase_files": {
         "task": "tapir.statistics.tasks.process_purchase_files",
-        "schedule": celery.schedules.crontab(minute=0, hour=2),
+        "schedule": celery.schedules.crontab(minute=0, hour=3),
     },
     "process_credit_account": {
         "task": "tapir.statistics.tasks.process_credit_account",
-        "schedule": celery.schedules.crontab(minute=0, hour=2),
+        "schedule": celery.schedules.crontab(minute=0, hour=3),
     },
     "send_create_account_reminder": {
         "task": "tapir.accounts.tasks.send_create_account_reminder",


### PR DESCRIPTION
Hi @Theophile-Madet, changed celery to 3am for purchase and credit according to the recommendation of Thilo: https://supercoopberlin.slack.com/archives/CHNUD32JJ/p1740688472716469?thread_ts=1740057789.713889&cid=CHNUD32JJ