### PR TITLE
fix: min-height for shift-block to avoid cut-off template name

### DIFF
--- a/tapir/shifts/templates/shifts/shift_block_tag.html
+++ b/tapir/shifts/templates/shifts/shift_block_tag.html
@@ -1,7 +1,8 @@
 {% load shifts %}
 {% load i18n %}
 {% load django_bootstrap5 %}
-<div class="shift-block-container" style="{{ shift.style }}">
+<div class="shift-block-container"
+     style="{{ shift.style }} min-height: 60px">
     <div id="{% if shift.is_template %}template{% else %}shift{% endif %}_{{ shift.id }}"
          class="shift-block btn btn-outline-dark {{ shift.filter_classes }}"
          style="height:{{ shift.height }}px">

--- a/tapir/translations/locale/de/LC_MESSAGES/django.po
+++ b/tapir/translations/locale/de/LC_MESSAGES/django.po
@@ -2,12 +2,12 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-16 14:46+0200\n"
+"POT-Creation-Date: 2025-09-22 16:59+0200\n"
 "PO-Revision-Date: 2025-07-07 13:06+0000\n"
 "Last-Translator: Weblate Admin <theo.madet@posteo.net>\n"
 "Language-Team: German <http://weblate.seriousdino.org/projects/tapir/tapir-python-translations/de/>\n"
@@ -3145,7 +3145,7 @@ msgid "This determines from which date shifts should be generated from this ABCD
 msgstr ""
 
 #: shifts/models.py:195 shifts/models.py:527
-#: shifts/templates/shifts/shift_block_tag.html:10
+#: shifts/templates/shifts/shift_block_tag.html:11
 msgid "Flexible time"
 msgstr "Zeit flexibel"
 


### PR DESCRIPTION
Resolves #668. Having it both for template and non-template shift-blocks creates a smoother appearance. 
<img width="841" height="201" alt="grafik" src="https://github.com/user-attachments/assets/9c5cd9ae-10b8-4a77-bdcc-e25468bfe942" />
Does the `60px` affect how it shows on mobile?