### PR TITLE
skip_postgeneration_save = True

### DIFF
--- a/tapir/shifts/tests/factories.py
+++ b/tapir/shifts/tests/factories.py
@@ -67,6 +67,7 @@ class ShiftFactory(factory.django.DjangoModelFactory[Shift]):
     class Meta:
         model = Shift
         exclude = ("start_hour", "start_minute", "duration", "nb_slots")
+        skip_postgeneration_save = True
 
     name = factory.Faker("bs")
 


### PR DESCRIPTION
I receive this warning
```
========================================================================================================= warnings summary =========================================================================================================
tapir/shifts/tests/test_shiftwatch_notification.py::ShiftWatchCommandTests::test_handle_ATTENDANCE_MINUS_onlySentIfThereAreNoOtherChanges
tapir/shifts/tests/test_shiftwatch_notification.py::ShiftWatchCommandTests::test_handle_ATTENDANCE_PLUS_onlySentIfThereAreNoOtherChanges
tapir/shifts/tests/test_shiftwatch_notification.py::ShiftWatchCommandTests::test_handle_shiftInThePast_noNotification
tapir/shifts/tests/test_shiftwatch_notification.py::ShiftWatchCommandTests::test_handle_triggeredMultipleTimes_onlyOneMailIsSend
tapir/shifts/tests/test_shiftwatch_notification.py::ShiftWatchCommandTests::test_handle_watchedShiftIsAlright_noNotificationIsSent
tapir/shifts/tests/test_shiftwatch_notification.py::ShiftWatchCommandTests::test_handle_watchedShiftIsCurrentlyRunning_correctNotificationIsSent
tapir/shifts/tests/test_shiftwatch_notification.py::ShiftWatchCommandTests::test_handle_watchedShiftIsUnderstaffed_correctNotificationIsSent
tapir/shifts/tests/test_shiftwatch_notification.py::ShiftWatchCommandTests::test_handle_watchingCoordinatorChanges_coordinatorNotificationsGetSent
  /root/.cache/pypoetry/virtualenvs/tapir-9TtSrW0h-py3.13/lib/python3.13/site-packages/factory/django.py:182: DeprecationWarning: ShiftFactory._after_postgeneration will stop saving the instance after postgeneration hooks in the next major release.
  If the save call is extraneous, set skip_postgeneration_save=True in the ShiftFactory.Meta.
  To keep saving the instance, move the save call to your postgeneration hooks or override _after_postgeneration.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

Since the post-factory changes are saved alreay when create was set, I assume it's fine to set `skip_postgeneration_save = True`