### PR TITLE
fix: change icon for cancelling whole day to event_busy

### DIFF
--- a/tapir/shifts/templates/shifts/shift_calendar_template.html
+++ b/tapir/shifts/templates/shifts/shift_calendar_template.html
@@ -81,7 +81,7 @@
                                 </a>
                                 <a href="{% url 'shifts:shift_day_cancel' day|date:'d-m-y' %}"
                                    class="{% tapir_button_link_to_action %}">
-                                    <span class="material-icons">free_cancellation</span>
+                                    <span class="material-icons">event_busy</span>
                                 </a>
                             {% endif %}
                         </h6>


### PR DESCRIPTION
Small one but I was confused about the icon. what do you think about `event_busy`?
<img width="578" height="431" alt="grafik" src="https://github.com/user-attachments/assets/61a7d8b9-d88d-496f-b173-36bb002db212" />
