### PR TITLE
fix: #748 avoid an error when displaying a user without last name in the welcome desk search page.

### DIFF
--- a/tapir/utils/tests/test_UserUtils.py
+++ b/tapir/utils/tests/test_UserUtils.py
@@ -133,3 +133,16 @@ class TestUserUtilsBuildDisplayName(SimpleTestCase):
             share_owner, UserUtils.DISPLAY_NAME_TYPE_WELCOME_DESK
         )
         self.assertEqual("Jane D. #12", display_name)
+
+    def test_displayTypeWelcomeDeskAndUserHasNoLastName_noErrorThrown(self):
+        # regression test for #748
+        share_owner = ShareOwnerFactory.build(
+            first_name=self.FIRST_NAME,
+            usage_name=self.USAGE_NAME,
+            last_name="",
+            id=12,
+        )
+        display_name = UserUtils.build_display_name(
+            share_owner, UserUtils.DISPLAY_NAME_TYPE_WELCOME_DESK
+        )
+        self.assertEqual("Jane . #12", display_name)

--- a/tapir/utils/user_utils.py
+++ b/tapir/utils/user_utils.py
@@ -29,7 +29,7 @@ class UserUtils:
         if display_type == cls.DISPLAY_NAME_TYPE_FULL:
             display_name = f"{display_name} {person.last_name}"
         elif display_type == cls.DISPLAY_NAME_TYPE_WELCOME_DESK:
-            display_name = f"{display_name} {person.last_name[0]}."
+            display_name = f"{display_name} {person.last_name[:1]}."
 
         if display_type in [
             cls.DISPLAY_NAME_TYPE_FULL,


### PR DESCRIPTION
Closes #748 