### PR TITLE
feat: #704 extend shareowner view with capability experience filter

### DIFF
--- a/tapir/accounts/models.py
+++ b/tapir/accounts/models.py
@@ -14,7 +14,10 @@ from ldap.ldapobject import LDAPObject
 from phonenumber_field.modelfields import PhoneNumberField
 
 from tapir import utils, settings
-from tapir.coop.config import get_ids_of_users_registered_to_a_shift_with_capability
+from tapir.coop.config import (
+    get_ids_of_users_registered_to_a_shift_with_capability,
+    get_ids_of_users_recently_completed_a_shift_with_capability,
+)
 from tapir.core.config import help_text_displayed_name
 from tapir.log.models import UpdateModelLogEntry
 from tapir.settings import (
@@ -51,6 +54,12 @@ class TapirUserQuerySet(models.QuerySet):
         return self.filter(
             shift_user_data__capabilities__contains=[capability]
         ).distinct()
+
+    def has_recent_capability_experience(self, capability: str):
+        user_ids = get_ids_of_users_recently_completed_a_shift_with_capability[0](
+            capability
+        )
+        return self.filter(id__in=user_ids).distinct()
 
 
 class TapirUserManager(UserManager.from_queryset(TapirUserQuerySet)):

--- a/tapir/coop/config.py
+++ b/tapir/coop/config.py
@@ -10,6 +10,7 @@ on_welcome_session_attendance_update = []
 # This is not very clean, we need a better solution to inject member filters from the shift app into the coop app
 # without adding a dependency from the coop app to the shift app
 get_ids_of_users_registered_to_a_shift_with_capability = []
+get_ids_of_users_recently_completed_a_shift_with_capability = []
 
 URL_MEMBER_MANUAL = "https://wiki.supercoop.de/wiki/Member_Manual"
 

--- a/tapir/coop/views/shareowner.py
+++ b/tapir/coop/views/shareowner.py
@@ -631,6 +631,14 @@ class ShareOwnerFilter(django_filters.FilterSet):
         method="has_capability_filter",
         label=_("Has qualification"),
     )
+    has_recent_capability_experience = ChoiceFilter(
+        choices=[
+            (capability, capability_name)
+            for capability, capability_name in SHIFT_USER_CAPABILITY_CHOICES.items()
+        ],
+        method="has_recent_capability_experience_filter",
+        label=_("Has completed a shift with this qualification in the last 6 months"),
+    )
     not_has_capability = ChoiceFilter(
         choices=[
             (capability, capability_name)
@@ -732,6 +740,14 @@ class ShareOwnerFilter(django_filters.FilterSet):
     ):
         return queryset.filter(
             user__in=TapirUser.objects.has_capability(value)
+        ).distinct()
+
+    @staticmethod
+    def has_recent_capability_experience_filter(
+        queryset: ShareOwner.ShareOwnerQuerySet, name, value: str
+    ):
+        return queryset.filter(
+            user__in=TapirUser.objects.has_recent_capability_experience(value)
         ).distinct()
 
     @staticmethod

--- a/tapir/shifts/apps.py
+++ b/tapir/shifts/apps.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext_lazy as _
 from tapir.coop.config import (
     on_welcome_session_attendance_update,
     get_ids_of_users_registered_to_a_shift_with_capability,
+    get_ids_of_users_recently_completed_a_shift_with_capability,
 )
 from tapir.core.config import sidebar_link_groups, feature_flag_solidarity_shifts
 from tapir.settings import PERMISSION_SHIFTS_MANAGE
@@ -29,6 +30,9 @@ class ShiftConfig(AppConfig):
 
         get_ids_of_users_registered_to_a_shift_with_capability.append(
             utils.get_ids_of_users_registered_to_a_shift_with_capability
+        )
+        get_ids_of_users_recently_completed_a_shift_with_capability.append(
+            utils.get_ids_of_users_recently_completed_a_shift_with_capability
         )
 
     @classmethod

--- a/tapir/shifts/utils.py
+++ b/tapir/shifts/utils.py
@@ -1,5 +1,5 @@
 from calendar import HTMLCalendar, month_name, day_abbr
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -139,6 +139,21 @@ def get_ids_of_users_registered_to_a_shift_with_capability(
         ShiftAttendance.objects.filter(
             slot__required_capabilities__contains=[capability],
             state__in=ShiftAttendance.STATES_WHERE_THE_MEMBER_IS_EXPECTED_TO_SHOW_UP,
+        )
+        .distinct()
+        .values_list("user__id", flat=True)
+    )
+
+
+def get_ids_of_users_recently_completed_a_shift_with_capability(
+    capability: ShiftUserCapability,
+):
+    six_months_ago = timezone.now().date() - timedelta(weeks=26)
+    return (
+        ShiftAttendance.objects.filter(
+            slot__required_capabilities__contains=[capability],
+            state__in=[ShiftAttendance.State.DONE],
+            slot__shift__start_time__gt=six_months_ago,
         )
         .distinct()
         .values_list("user__id", flat=True)


### PR DESCRIPTION
The filter checks whether the user completed a shift in the last 6 months that required the selected capability.