### PR TITLE
fix(log): stabilize hstore audit snapshots

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,15 @@ services:
       context: .
       args:
           ARG_VERSION: ""
+          POETRY_INSTALL_DEV: "true"
       dockerfile: ./django.Dockerfile
-    command: bash -c "poetry install &&
+    command: bash -c "poetry install --with dev &&
                       poetry run python manage.py compilemessages --ignore \".venv\" &&
                       poetry run python manage.py runserver_plus 0.0.0.0:80"
     volumes:
       - .:/app
+      # Keep container's virtualenv isolated from host .venv so dev deps (pytest) are available
+      - web-venv:/app/.venv
     environment:
       VIRTUAL_HOST: localhost
       DEBUG: 1
@@ -69,7 +72,7 @@ services:
   celery:
     extends:
       service: web
-    command: bash -c "poetry install &&
+    command: bash -c "poetry install --with dev &&
                       poetry run celery -A tapir worker -l info"
     depends_on:
       - redis
@@ -78,7 +81,7 @@ services:
     extends:
       service: web
     # --schedule to avoid polluting the app directory
-    command: bash -c "poetry install &&
+    command: bash -c "poetry install --with dev &&
                       poetry run celery -A tapir beat -l info --schedule /tmp/celerybeat-schedule"
     depends_on:
       - redis
@@ -95,3 +98,4 @@ services:
 
 volumes:
   nginx-certs-volume:
+  web-venv:

--- a/poetry.lock
+++ b/poetry.lock
@@ -4344,4 +4344,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "aa0aa814f5cc8077f228e8c03d4f6f7e280ec35b51a00ea40c3851117bbb8567"
+content-hash = "d2e75a31528ec01d6664671c63aa80c2bc1b6d0988bbd0b5feb583d677d86599"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "slack-sdk (>=3.35.0,<4.0.0)",
     "holidays (>=0.93,<0.94)",
     "drf-spectacular (>=0.29.0,<0.30.0)",
+    "python-ldap (>=3.4.5,<4.0.0)",
 ]
 
 [tool.poetry.group.dev.dependencies]

--- a/tapir/accounts/tests/test_update_tapir_user_log_entry.py
+++ b/tapir/accounts/tests/test_update_tapir_user_log_entry.py
@@ -1,0 +1,38 @@
+from tapir.accounts.models import UpdateTapirUserLogEntry
+from tapir.accounts.tests.factories.factories import TapirUserFactory
+from tapir.log.util import freeze_for_log
+from tapir.utils.tests_utils import TapirFactoryTestBase
+
+
+class TestUpdateTapirUserLogEntry(TapirFactoryTestBase):
+    def test_hstore_values_round_trip_as_dict_and_render(self):
+        tapir_user = TapirUserFactory.create()
+
+        UpdateTapirUserLogEntry().populate(
+            actor=tapir_user,
+            tapir_user=tapir_user,
+            old_frozen={"phone_number": "before"},
+            new_frozen={"phone_number": "after"},
+        ).save()
+
+        log_entry = UpdateTapirUserLogEntry.objects.get()
+
+        self.assertIsInstance(log_entry.old_values, dict)
+        self.assertIsInstance(log_entry.new_values, dict)
+        self.assertEqual({"phone_number": "before"}, log_entry.old_values)
+        self.assertEqual({"phone_number": "after"}, log_entry.new_values)
+        self.assertEqual(
+            [("phone_number", "before", "after")],
+            log_entry.get_context_data()["changes"],
+        )
+        self.assertIn(
+            "<strong>phone_number</strong>: before → after",
+            log_entry.render(),
+        )
+
+    def test_freeze_for_log_excludes_password(self):
+        tapir_user = TapirUserFactory.create()
+
+        frozen = freeze_for_log(tapir_user)
+
+        self.assertNotIn("password", frozen)

--- a/tapir/log/apps.py
+++ b/tapir/log/apps.py
@@ -1,9 +1,52 @@
 from django.apps import AppConfig
+from django.contrib.postgres.signals import get_hstore_oids, register_type_handlers
+from django.core.signals import request_started
+from django.db import connections
+from django.db.backends.base.base import NO_DB_ALIAS
+from django.db.backends.signals import connection_created
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 
 from tapir.core.config import sidebar_link_groups
 from tapir.settings import PERMISSION_COOP_MANAGE
+
+HSTORE_CONNECTION_MARKER = "_tapir_hstore_registered_connection"
+
+
+def ensure_hstore_type_handlers(connection) -> bool:
+    """Register HStore adapters for the current raw PostgreSQL connection.
+
+    A web process can open its connection before the migration that creates the
+    HStore extension runs in another process. Django then caches the empty OID
+    lookup. Retry the lookup until the extension exists and remember successful
+    registration for the lifetime of the raw connection.
+    """
+    if connection.vendor != "postgresql" or connection.alias == NO_DB_ALIAS:
+        return False
+
+    raw_connection = connection.connection
+    if raw_connection is None:
+        return False
+    if getattr(connection, HSTORE_CONNECTION_MARKER, None) is raw_connection:
+        return True
+
+    get_hstore_oids.cache_clear()
+    oids, _ = get_hstore_oids(connection.alias)
+    if not oids:
+        return False
+
+    register_type_handlers(connection)
+    setattr(connection, HSTORE_CONNECTION_MARKER, raw_connection)
+    return True
+
+
+def ensure_hstore_on_connection_created(sender, connection, **kwargs):
+    ensure_hstore_type_handlers(connection)
+
+
+def ensure_hstore_for_open_connections(**kwargs):
+    for connection in connections.all(initialized_only=True):
+        ensure_hstore_type_handlers(connection)
 
 
 class LogConfig(AppConfig):
@@ -11,6 +54,7 @@ class LogConfig(AppConfig):
 
     def ready(self):
         self.register_sidebar_link_groups()
+        self._register_db_signal_handlers()
 
     @staticmethod
     def register_sidebar_link_groups():
@@ -21,3 +65,17 @@ class LogConfig(AppConfig):
             ordering=1,
             required_permissions=[PERMISSION_COOP_MANAGE],
         )
+
+    @staticmethod
+    def _register_db_signal_handlers():
+        connection_created.connect(
+            ensure_hstore_on_connection_created,
+            dispatch_uid="tapir.log.ensure_hstore_on_connection_created",
+            weak=False,
+        )
+        request_started.connect(
+            ensure_hstore_for_open_connections,
+            dispatch_uid="tapir.log.ensure_hstore_for_open_connections",
+            weak=False,
+        )
+        ensure_hstore_for_open_connections()

--- a/tapir/log/models.py
+++ b/tapir/log/models.py
@@ -244,9 +244,12 @@ class ModelLogEntry(LogEntry):
     ):
         frozen = freeze_for_log(model) if model else frozen
 
-        if hasattr(self, "exclude_fields"):
-            for k in self.exclude_fields:
-                del frozen[k]
+        fields_to_exclude = [
+            *getattr(self, "excluded_fields", ()),
+            *getattr(self, "exclude_fields", ()),
+        ]
+        for k in fields_to_exclude:
+            frozen.pop(k, None)
 
         self.values = frozen
         return super().populate_base(

--- a/tapir/log/tests/__init__.py
+++ b/tapir/log/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the audit log application."""

--- a/tapir/log/tests/test_apps.py
+++ b/tapir/log/tests/test_apps.py
@@ -1,0 +1,114 @@
+from types import SimpleNamespace
+from unittest.mock import call, patch
+
+from django.db import OperationalError
+from django.db.backends.base.base import NO_DB_ALIAS
+from django.test import SimpleTestCase
+
+from tapir.log.apps import (
+    HSTORE_CONNECTION_MARKER,
+    ensure_hstore_for_open_connections,
+    ensure_hstore_type_handlers,
+)
+
+
+def postgres_connection():
+    return SimpleNamespace(
+        alias="default",
+        connection=object(),
+        vendor="postgresql",
+    )
+
+
+class TestEnsureHstoreTypeHandlers(SimpleTestCase):
+    @patch("tapir.log.apps.register_type_handlers")
+    @patch("tapir.log.apps.get_hstore_oids")
+    def test_ignores_non_postgresql_connections(
+        self, get_hstore_oids, register_type_handlers
+    ):
+        connection = SimpleNamespace(connection=object(), vendor="sqlite")
+
+        self.assertFalse(ensure_hstore_type_handlers(connection))
+
+        get_hstore_oids.cache_clear.assert_not_called()
+        get_hstore_oids.assert_not_called()
+        register_type_handlers.assert_not_called()
+
+    @patch("tapir.log.apps.register_type_handlers")
+    @patch("tapir.log.apps.get_hstore_oids")
+    def test_ignores_django_no_database_connection(
+        self, get_hstore_oids, register_type_handlers
+    ):
+        connection = postgres_connection()
+        connection.alias = NO_DB_ALIAS
+
+        self.assertFalse(ensure_hstore_type_handlers(connection))
+
+        get_hstore_oids.cache_clear.assert_not_called()
+        get_hstore_oids.assert_not_called()
+        register_type_handlers.assert_not_called()
+
+    @patch("tapir.log.apps.register_type_handlers")
+    @patch("tapir.log.apps.get_hstore_oids")
+    def test_retries_after_hstore_extension_becomes_available(
+        self, get_hstore_oids, register_type_handlers
+    ):
+        connection = postgres_connection()
+        get_hstore_oids.side_effect = [((), ()), ((1234,), (1235,))]
+
+        self.assertFalse(ensure_hstore_type_handlers(connection))
+        self.assertTrue(ensure_hstore_type_handlers(connection))
+        self.assertTrue(ensure_hstore_type_handlers(connection))
+
+        self.assertIs(
+            connection.connection,
+            getattr(connection, HSTORE_CONNECTION_MARKER),
+        )
+        self.assertEqual(2, get_hstore_oids.cache_clear.call_count)
+        self.assertEqual(2, get_hstore_oids.call_count)
+        register_type_handlers.assert_called_once_with(connection)
+
+    @patch("tapir.log.apps.register_type_handlers")
+    @patch("tapir.log.apps.get_hstore_oids", return_value=((1234,), (1235,)))
+    def test_registers_again_for_a_reopened_raw_connection(
+        self, get_hstore_oids, register_type_handlers
+    ):
+        connection = postgres_connection()
+
+        self.assertTrue(ensure_hstore_type_handlers(connection))
+        connection.connection = object()
+        self.assertTrue(ensure_hstore_type_handlers(connection))
+
+        self.assertEqual(2, get_hstore_oids.cache_clear.call_count)
+        self.assertEqual(2, get_hstore_oids.call_count)
+        self.assertEqual(
+            [call(connection), call(connection)],
+            register_type_handlers.call_args_list,
+        )
+
+    @patch("tapir.log.apps.register_type_handlers")
+    @patch("tapir.log.apps.get_hstore_oids")
+    def test_does_not_hide_database_errors(
+        self, get_hstore_oids, register_type_handlers
+    ):
+        connection = postgres_connection()
+        get_hstore_oids.side_effect = OperationalError("database unavailable")
+
+        with self.assertRaises(OperationalError):
+            ensure_hstore_type_handlers(connection)
+
+        register_type_handlers.assert_not_called()
+
+    @patch("tapir.log.apps.ensure_hstore_type_handlers")
+    @patch("tapir.log.apps.connections.all")
+    def test_rechecks_all_initialized_connections(self, all_connections, ensure_hstore):
+        connections = [postgres_connection(), postgres_connection()]
+        all_connections.return_value = connections
+
+        ensure_hstore_for_open_connections()
+
+        all_connections.assert_called_once_with(initialized_only=True)
+        self.assertEqual(
+            [call(connections[0]), call(connections[1])],
+            ensure_hstore.call_args_list,
+        )

--- a/tapir/log/util.py
+++ b/tapir/log/util.py
@@ -9,7 +9,6 @@ def freeze_for_log(instance) -> dict:
         data[field.name] = field.value_from_object(instance)
     for field in opts.many_to_many:
         data[field.name] = [i.id for i in field.value_from_object(instance)]
-    if hasattr(instance, "excluded_fields"):
-        for field in instance.excluded_fields_for_logs:
-            del data[field]
+    for field in getattr(instance, "excluded_fields_for_logs", ()):
+        data.pop(field, None)
     return data


### PR DESCRIPTION
# Fix intermittent HStore audit log failures

## Summary

This PR fixes the intermittent HStore failures reported in #272. It makes HStore adapter registration recover when the web process opens a PostgreSQL connection before the migration process creates the `hstore` extension.

The fix re-checks HStore availability for newly created connections and at the start of later requests. Once registration succeeds, it is remembered for the lifetime of the underlying raw database connection.

The PR also contains additional changes: it fixes audit snapshot field-exclusion handling so that sensitive fields such as passwords are not persisted, and it adjusts the development Docker environment so the regression tests can run with the required development dependencies.

Fixes #272.

## Reproduction before the fix

We reproduced the problem with newly created Docker volumes. Following the README startup order, the web process was allowed to connect to PostgreSQL before migrations were applied. This reproduces the timing condition that leaves the web process with a stale HStore OID lookup.

Using generated synthetic test data, we then followed the reported workflow:

1. Log in as the generated test user Roberto Cortes.
2. Create a note on the user's profile.
3. Edit the profile.
4. Change the language from English to German.
5. Replace the invalid default phone number with `+12125552368`.
6. Save the profile.

Before the fix, saving the audited change failed. In our reproduction, the exception was:

```text
django.db.utils.ProgrammingError

django.db.utils.ProgrammingError: can't adapt type 'dict'
```

The relevant part of the traceback was:

```text
File "/app/tapir/accounts/views.py", line 106, in form_valid
    ).save()

File "/app/tapir/log/models.py", line 62, in save
    super(LogEntry, self).save(*args, **kwargs)

django.db.utils.ProgrammingError: can't adapt type 'dict'
```

This failure happened while saving the audit log, before reaching the original read-side symptom from #272:

```text
'str' object has no attribute 'keys'
```

Both symptoms have the same underlying cause: the PostgreSQL connection used by the web process did not have working HStore type handlers.

## Root cause

A Django web process may open its PostgreSQL connection before migrations create the `hstore` extension. During connection initialization, Django then caches an empty HStore OID lookup and cannot register the HStore adapters.

Creating the extension later clears that cache only in the migration process. The already running web process continues using its existing connection without HStore adapters.

The `connection_created` signal alone cannot recover this connection: it was already emitted when the connection was first opened, before HStore existed, and the same raw connection may remain open after the migration.

As a result, dictionaries cannot be adapted when writing an `HStoreField`, or HStore values are decoded as strings when reading them.

## Fix

- Clear and re-run Django's HStore OID lookup when checking an unregistered PostgreSQL connection.
- Register the adapters through Django's own PostgreSQL type-handler implementation.
- Check already initialized connections once when the signal handlers are registered.
- Check newly created connections through `connection_created`.
- Re-check already open connections through `request_started`, allowing a connection that was opened before the migration to recover on a later request.
- Remember successful registration for the lifetime of each raw database connection and register again after a reconnect.
- Allow database errors to propagate instead of hiding configuration or connectivity problems with broad exception handling.

The request-start check is inexpensive for an already registered raw connection: the connection is marked as registered, so later checks of the same raw connection return without repeating the OID lookup or adapter registration.

The fix is applied at the database connection boundary. It does not add a defensive JSON or string decoder that could conceal an incorrectly configured HStore connection.

## Related changes

### Audit snapshot field exclusion

Field exclusion happens at two points:

- `freeze_for_log()` reads `excluded_fields_for_logs` from the domain model. This now correctly removes fields such as `TapirUser.password` before the snapshot is returned.
- `ModelLogEntry.populate_base()` now recognizes both `excluded_fields` and `exclude_fields` when populating a log entry's `values` snapshot.

Both paths use non-failing removal so that a configured field does not cause an error when it is absent from the snapshot.

### Development environment

The Docker development setup now keeps the container's virtual environment separate from a host-side `.venv` and installs the development dependencies required to run the focused regression tests. The project also declares its direct `python-ldap` dependency explicitly.

These environment changes support local verification but are independent of the runtime HStore registration fix.

## Verification

### Focused automated tests

The focused regression suite passed:

```text
8 passed in 7.81s
```

It covers:

- retrying on a later check after the HStore extension becomes available;
- registering handlers again after the raw connection changes;
- ignoring non-PostgreSQL and Django's no-database connections;
- propagating database errors instead of swallowing them;
- checking all initialized database connections;
- saving and reloading audit snapshots as dictionaries;
- rendering a reloaded audit entry;
- excluding the password from frozen user snapshots.

The test command was:

```sh
docker compose exec -T web poetry run pytest \
  tapir/log/tests/test_apps.py \
  tapir/accounts/tests/test_update_tapir_user_log_entry.py -q
```

### Fresh-container startup test

We removed the existing Docker volumes and recreated the services from scratch. The web process was deliberately allowed to connect to PostgreSQL before migrations were applied. We then applied all migrations and generated synthetic test data without restarting the web process.

The first request after the migration reached the login form successfully, and the web container's restart count remained zero. This confirms that the already running process continued serving requests without requiring a restart. The subsequent audited profile update verified that HStore registration had recovered. Depending on the database connection lifecycle, registration occurs either when `request_started` re-checks an existing raw connection or when `connection_created` initializes a replacement connection.

### Manual browser verification

We then repeated the original audited profile-update workflow:

1. Create a note.
2. Change the language to German.
3. Enter `+12125552368` as the phone number.
4. Save the profile.

The save completed successfully. The request returned a redirect instead of an HTTP 500 response, and the web logs contained no `ProgrammingError`. This confirms that the audited HStore write succeeded in the web process that had been started before the migration.

We additionally inspected the persisted audit entry and confirmed:

```text
phone_number: +12125552368
old_values type: dict
new_values type: dict
logged new phone number: +12125552368
```

Manual inspection of the persisted entry confirmed that both HStore fields were decoded as dictionaries. The focused integration test additionally reloads and renders the entry, covering the original read-side failure.

Formatting and targeted lint checks passed. `manage.py check` only reported the pre-existing warning about the missing development `dist` directory, and `poetry check --lock` passed with its pre-existing license deprecation warning.
