### PR TITLE
Potential fix for code scanning alert no. 47: DOM text reinterpreted as HTML

### DIFF
--- a/tapir/shifts/templates/shifts/shift_calendar_template.html
+++ b/tapir/shifts/templates/shifts/shift_calendar_template.html
@@ -15,10 +15,14 @@
                 return;
             }
 
-            let url = "{% url 'shifts:calendar' %}";
-            url += "?date_from=" + document.getElementById("date-from").value;
-            url += "&date_to=" + document.getElementById("date-to").value;
-            window.location = url;
+            const baseUrl = "{% url 'shifts:calendar' %}";
+            const dateFrom = document.getElementById("date-from").value;
+            const dateTo = document.getElementById("date-to").value;
+            const params = new URLSearchParams({
+                date_from: dateFrom,
+                date_to: dateTo,
+            });
+            window.location = `${baseUrl}?${params.toString()}`;
         }
     </script>
 {% endblock head %}


### PR DESCRIPTION
Potential fix for [https://github.com/SuperCoopBerlin/tapir/security/code-scanning/47](https://github.com/SuperCoopBerlin/tapir/security/code-scanning/47)

Use safe query parameter construction instead of string concatenation.  
Best fix: replace manual `url += "..."+value` with `URLSearchParams` (or `encodeURIComponent`) so user-provided values are encoded before being placed in the URL query string.

In `tapir/shifts/templates/shifts/shift_calendar_template.html`, within `onFilter()` (lines 18–21 in the provided snippet), replace the concatenation logic with:

- read `date-from` and `date-to` values into variables,
- create `new URLSearchParams({...})`,
- set `window.location` to `${baseUrl}?${params.toString()}`.

This preserves behavior (redirect to the same endpoint with `date_from` and `date_to`) while preventing unsafe reinterpretation of special characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
